### PR TITLE
Removed prints statements.

### DIFF
--- a/implants/eldritch/src/process/list_impl.rs
+++ b/implants/eldritch/src/process/list_impl.rs
@@ -91,12 +91,10 @@ mod tests {
             .arg("5")
             .spawn()?;
         
-        println!("{:?}", child.id());
         let res = list()?;
         let searchstring = String::from(format!("pid:{}", child.id()));
         for proc in res{
             if proc.as_str().contains(&searchstring) {
-                println!("{:?}", proc.to_string());
                 if proc.as_str().contains("command:\\\"sleep 5\\\"") {
                     assert_eq!(true, true);
                 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:
Removes print statements from eldritch `proc.list`

