### PR TITLE
[Tavern][bugfix] Fixed issue with transactional client

### DIFF
--- a/tavern/graphql/job_test.go
+++ b/tavern/graphql/job_test.go
@@ -159,11 +159,21 @@ func TestCreateJob(t *testing.T) {
 func newCreateJobTest(gqlClient *client.Client, sessionIDs []int, input ent.CreateJobInput, checks ...func(t *testing.T, id int, err error)) func(t *testing.T) {
 	return func(t *testing.T) {
 		// Define the mutatation for testing, taking the input as a variable
-		mut := `mutation newCreateJobTest($sessionIDs: [ID!]!, $input: CreateJobInput!) { createJob(sessionIDs:$sessionIDs, input:$input) { id } }`
+		mut := `mutation newCreateJobTest($sessionIDs: [ID!]!, $input: CreateJobInput!) { createJob(sessionIDs:$sessionIDs, input:$input) { 
+			id
+			tasks {
+				id
+			}
+		} }`
 
 		// Make our request to the GraphQL API
 		var resp struct {
-			CreateJob struct{ ID string }
+			CreateJob struct {
+				ID    string
+				Tasks []struct {
+					ID string
+				} `json:"tasks"`
+			}
 		}
 		err := gqlClient.Post(mut, &resp,
 			client.Var("sessionIDs", sessionIDs),

--- a/tavern/graphql/session_test.go
+++ b/tavern/graphql/session_test.go
@@ -74,14 +74,22 @@ func TestSessionMutations(t *testing.T) {
 		mut := `
 mutation newClaimTasksTest($input: ClaimTasksInput!) {
 	claimTasks(input: $input) {
-		id 
+		id
+		job {
+			id
+		}
 	}
 }`
 		// Create a closure to execute the mutation
 		claimTasks := func(input map[string]any) ([]int, error) {
 			// Make our request to the GraphQL API
 			var resp struct {
-				ClaimTasks []struct{ ID string }
+				ClaimTasks []struct {
+					ID  string
+					Job struct {
+						ID string
+					} `json:"job"`
+				}
 			}
 			err := gqlClient.Post(mut, &resp, client.Var("input", input))
 			if err != nil {
@@ -163,7 +171,7 @@ mutation newClaimTasksTest($input: ClaimTasksInput!) {
 		mut := `
 mutation newSubmitTaskResultTest($input: SubmitTaskResultInput!) {
 	submitTaskResult(input: $input) {
-		id 
+		id
 	}
 }`
 		// Create a closure to execute the mutation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind bugfix

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:
Updates two of our mutations (`claimTasks` and `createJob`) to reload ents that were created/updated with the transactional client before returning them. This is because when the transactional client is used to commit the transaction, it can no longer be used to load ents. For regular usage this was fine, but the bug was encountered when attempting to traverse edges on the result (see the example mutation below). This is because the returned ent(s) would have embedded the transactional `*ent.Client`, because that's the client they were loaded with. Further queries using that client would error, meaning additional graph traversals would fail like the example below:

```
mutation BugExample($sessionIDs: [ID!]!, $input: CreateJobInput!) {
    createJob(sessionIDs: $sessionIDs, input: $input) {
         id
        tasks {
            id
        }
    }
}
```

This produces a GraphQL error "sql: transaction has already been committed or rolled back".

Our test cases were updated to reflect the more complex queries that real world users may have to prevent regression.
