### PR TITLE
Removed high resource portscan test.

### DIFF
--- a/implants/eldritch/src/pivot/port_scan_impl.rs
+++ b/implants/eldritch/src/pivot/port_scan_impl.rs
@@ -586,23 +586,23 @@ mod tests {
     // }
 
     // Test scanning a lot of ports all at once. Can the OS handle it.
-    #[tokio::test]
-    async fn test_portscan_tcp_max() -> anyhow::Result<()>{
-        if cfg!(target_os = "windows") { // Windows TCP max port scan doesn't work on localhost.
-            let test_ports: Vec<i32> =  (1..65535).map(|x| x).collect();
+    // #[tokio::test]
+    // async fn test_portscan_tcp_max() -> anyhow::Result<()>{
+    //     if cfg!(target_os = "windows") { // Windows TCP max port scan doesn't work on localhost.
+    //         let test_ports: Vec<i32> =  (1..65535).map(|x| x).collect();
 
-            let test_cidr =  vec!["192.168.119.2/32".to_string()];
+    //         let test_cidr =  vec!["192.168.119.2/32".to_string()];
 
-            let _scan_res = handle_port_scan(test_cidr, test_ports.clone(), String::from("tcp"), 5).await?;
-        }else {
-            let test_ports: Vec<i32> =  (1..65535).map(|x| x).collect();
+    //         let _scan_res = handle_port_scan(test_cidr, test_ports.clone(), String::from("tcp"), 5).await?;
+    //     }else {
+    //         let test_ports: Vec<i32> =  (1..65535).map(|x| x).collect();
 
-            let test_cidr =  vec!["127.0.0.1/32".to_string()];
+    //         let test_cidr =  vec!["127.0.0.1/32".to_string()];
 
-            let _scan_res = handle_port_scan(test_cidr, test_ports.clone(), String::from("tcp"), 5).await?;
-        }
-        Ok(())
-    }
+    //         let _scan_res = handle_port_scan(test_cidr, test_ports.clone(), String::from("tcp"), 5).await?;
+    //     }
+    //     Ok(())
+    // }
 
     // verify our non async call works and Dict return type.
     #[test]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:
Portscanning has been causing other tests to fail. This test isn't needed.

#### Which issue(s) this PR fixes:
Fixes #109 
