### PR TITLE
Cleaned up complier error and test inconsistency.

### DIFF
--- a/implants/eldritch/src/process/list_impl.rs
+++ b/implants/eldritch/src/process/list_impl.rs
@@ -1,6 +1,8 @@
 use anyhow::{Result};
-use sysinfo::{ProcessExt,System,SystemExt,PidExt,User,UserExt};
+use sysinfo::{ProcessExt,System,SystemExt,PidExt};
 use  std::fmt;
+#[cfg(not(target_os = "windows"))]
+use sysinfo::{User,UserExt};
 
 pub struct ProcessRes {
     pid:        u32,
@@ -42,6 +44,7 @@ pub fn list() -> Result<Vec<String>> {
     let mut sys = System::new();
     sys.refresh_processes();
     sys.refresh_users_list();
+    #[cfg(not(target_os = "windows"))]
     let user_list =  sys.users().clone();
 
     for (pid, process) in sys.processes() {
@@ -51,7 +54,7 @@ pub fn list() -> Result<Vec<String>> {
         }
 
         #[cfg(target_os = "windows")]
-        let mut tmp_username = String::from("???");
+        let tmp_username = String::from("???");
         #[cfg(not(target_os = "windows"))]
         let tmp_username = uid_to_username(process.uid, user_list);
 
@@ -71,6 +74,7 @@ pub fn list() -> Result<Vec<String>> {
     Ok(res)
 }
 
+#[cfg(not(target_os = "windows"))]
 fn uid_to_username(username: u32, user_list: &[User]) -> String {
     for user in user_list {
         if *user.uid() == username {
@@ -87,10 +91,15 @@ mod tests {
 
     #[test]
     fn test_process_list() -> anyhow::Result<()>{
-        let child = Command::new("sleep")
+        #[cfg(not(target_os = "windows"))]
+        let sleep_str = "sleep";
+        #[cfg(target_os = "windows")]
+        let sleep_str = "timeout";
+
+        let child = Command::new(sleep_str)
             .arg("5")
             .spawn()?;
-        
+    
         let res = list()?;
         let searchstring = String::from(format!("pid:{}", child.id()));
         for proc in res{

--- a/implants/eldritch/src/sys/exec_impl.rs
+++ b/implants/eldritch/src/sys/exec_impl.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
-use std::process::{Command, exit};
+use std::process::Command;
 use std::str;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use nix::{sys::wait::waitpid, unistd::{fork, ForkResult}};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::process::exit;
 
 // https://stackoverflow.com/questions/62978157/rust-how-to-spawn-child-process-that-continues-to-live-after-parent-receives-si#:~:text=You%20need%20to%20double%2Dfork,is%20not%20related%20to%20rust.&text=You%20must%20not%20forget%20to,will%20become%20a%20zombie%20process.
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind eldritch-function
/kind failing-test
/kind regression

#### What this PR does / why we need it:
Cleans up compiler warnings and an inconsistency in the windows test on most windows VMs.

#### Which issue(s) this PR fixes:
Fixes #98 
