### PR TITLE
Fix async eldritch functions crashing golem/imix.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,9 @@ jobs:
         key: ${{ runner.os }}-imix-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-imix-cargo-
+    - if matrix.os == 'windows-latest'
+      run: powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
+      shell: powershell
     - name: 🔨 Build
       run: cd implants/imix && cargo build --verbose
     - name: 🔎 Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         key: ${{ runner.os }}-imix-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-imix-cargo-
-    - if matrix.os == 'windows-latest'
+    - if: matrix.os == 'windows-latest'
       run: powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
       shell: powershell
     - name: 🔨 Build
@@ -82,6 +82,9 @@ jobs:
         key: ${{ runner.os }}-eldritch-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-eldritch-cargo-
+    - if: matrix.os == 'windows-latest'
+      run: powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
+      shell: powershell
     - name: 🔨 Build
       run: cd implants/eldritch && cargo build --verbose
     - name: 🔎 Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
           ${{ runner.os }}-imix-cargo-
     - if: matrix.os == 'windows-latest'
       run: start-process -filepath powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
+      name: 👾 Disable defender
       shell: powershell
     - name: 🔨 Build
       run: cd implants/imix && cargo build --verbose
@@ -84,6 +85,7 @@ jobs:
           ${{ runner.os }}-eldritch-cargo-
     - if: matrix.os == 'windows-latest'
       run: start-process -filepath powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
+      name: 👾 Disable defender
       shell: powershell
     - name: 🔨 Build
       run: cd implants/eldritch && cargo build --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-imix-cargo-
     - if: matrix.os == 'windows-latest'
-      run: powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
+      run: start-process -filepath powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
       shell: powershell
     - name: 🔨 Build
       run: cd implants/imix && cargo build --verbose
@@ -83,7 +83,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-eldritch-cargo-
     - if: matrix.os == 'windows-latest'
-      run: powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
+      run: start-process -filepath powershell -ArgumentList '/c','Set-MpPreference -DisableRealtimeMonitoring $true' -verb RunAs
       shell: powershell
     - name: 🔨 Build
       run: cd implants/eldritch && cargo build --verbose

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -29,6 +29,7 @@ pub fn get_eldritch() -> anyhow::Result<Globals> {
 }
 
 pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameters: Option<String>) -> anyhow::Result<String> {
+    // Boilder plate
     let ast: AstModule;
     match AstModule::parse(
             &tome_filename,
@@ -41,7 +42,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
 
     let tome_params_str: String = match tome_parameters {
         Some(param_string) => param_string,
-        None => "".to_string(),
+        None => "{}".to_string(),
     };
 
     let globals = get_eldritch()?;
@@ -50,7 +51,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
 
     let res: SmallMap<Value, Value> = SmallMap::new();
     let mut input_params: Dict = Dict::new(res);
-
+    
     let parsed: serde_json::Value = serde_json::from_str(&tome_params_str)?;
     let param_map: serde_json::Map<String, serde_json::Value> = match parsed.as_object() {
         Some(tmp_param_map) => tmp_param_map.clone(),

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -209,7 +209,6 @@ file.download("https://www.google.com/", "{path}")
         let _ = test_res.join();
 
         assert!(tmp_file.as_file().metadata().unwrap().len() > 5);
-        let _ = tmp_file.close();
         Ok(())
     }
 

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -200,7 +200,7 @@ input_params
         println!("[DOWNLOAD] ASYNC START");
         // just using a temp file for its path
         let tmp_file = NamedTempFile::new()?;
-        let path = String::from(tmp_file.path().to_str().unwrap()).clone();
+        let path = String::from(tmp_file.path().to_str().unwrap()).clone().replace("\\", "\\\\");
         println!("[DOWNLOAD] PATH ALLOCATED");
         let test_content = format!(r#"
 file.download("https://www.google.com/", "{path}")

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -197,18 +197,23 @@ input_params
 
     #[tokio::test]
     async fn test_library_async() -> anyhow::Result<()> {
+        println!("[DOWNLOAD] ASYNC START");
         // just using a temp file for its path
         let tmp_file = NamedTempFile::new()?;
         let path = String::from(tmp_file.path().to_str().unwrap()).clone();
-                
+        println!("[DOWNLOAD] PATH ALLOCATED");
         let test_content = format!(r#"
 file.download("https://www.google.com/", "{path}")
 "#);
-
+        println!("[DOWNLOAD] CONTENT CREATED");
         let test_res = thread::spawn(|| { eldritch_run("test.tome".to_string(), test_content, None) });
+        println!("[DOWNLOAD] THREAD CREATED");
         let _ = test_res.join();
+        println!("[DOWNLOAD] THREAD JOINED");
 
         assert!(tmp_file.as_file().metadata().unwrap().len() > 5);
+        println!("[DOWNLOAD] ASSERTED");
+
         Ok(())
     }
 }

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -197,26 +197,16 @@ input_params
 
     #[tokio::test]
     async fn test_library_async() -> anyhow::Result<()> {
-        println!("[DOWNLOAD] ASYNC START");
         // just using a temp file for its path
         let tmp_file = NamedTempFile::new()?;
         let path = String::from(tmp_file.path().to_str().unwrap()).clone().replace("\\", "\\\\");
-        println!("[DOWNLOAD] PATH ALLOCATED");
         let test_content = format!(r#"
 file.download("https://www.google.com/", "{path}")
 "#);
-        println!("[DOWNLOAD] CONTENT CREATED");
         let test_res = thread::spawn(|| { eldritch_run("test.tome".to_string(), test_content, None) });
-        println!("[DOWNLOAD] THREAD CREATED");
         let test_val = test_res.join();
-        println!("{:?}", test_val.unwrap());
-        println!("[DOWNLOAD] THREAD JOINED");
 
-        println!("{:?}", tmp_file.as_file().metadata());
-        println!("{:?}", tmp_file.as_file().metadata().unwrap());
-        println!("{:?}", tmp_file.as_file().metadata().unwrap().len());
         assert!(tmp_file.as_file().metadata().unwrap().len() > 5);
-        println!("[DOWNLOAD] ASSERTED");
 
         Ok(())
     }

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -211,5 +211,4 @@ file.download("https://www.google.com/", "{path}")
         assert!(tmp_file.as_file().metadata().unwrap().len() > 5);
         Ok(())
     }
-
 }

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -206,10 +206,10 @@ file.download("https://www.google.com/", "{path}")
 "#);
 
         let test_res = thread::spawn(|| { eldritch_run("test.tome".to_string(), test_content, None) });
-        test_res.join();
-        
+        let _ = test_res.join();
+
         assert!(tmp_file.as_file().metadata().unwrap().len() > 5);
-        tmp_file.close();
+        let _ = tmp_file.close();
         Ok(())
     }
 

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -208,9 +208,13 @@ file.download("https://www.google.com/", "{path}")
         println!("[DOWNLOAD] CONTENT CREATED");
         let test_res = thread::spawn(|| { eldritch_run("test.tome".to_string(), test_content, None) });
         println!("[DOWNLOAD] THREAD CREATED");
-        let _ = test_res.join();
+        let test_val = test_res.join();
+        println!("{:?}", test_val.unwrap());
         println!("[DOWNLOAD] THREAD JOINED");
 
+        println!("{:?}", tmp_file.as_file().metadata());
+        println!("{:?}", tmp_file.as_file().metadata().unwrap());
+        println!("{:?}", tmp_file.as_file().metadata().unwrap().len());
         assert!(tmp_file.as_file().metadata().unwrap().len() > 5);
         println!("[DOWNLOAD] ASSERTED");
 

--- a/implants/eldritch/src/sys/dll_inject_impl.rs
+++ b/implants/eldritch/src/sys/dll_inject_impl.rs
@@ -78,58 +78,58 @@ pub fn dll_inject(dll_path: String, pid: u32) -> Result<NoneType> {
     }
 }
 
-// #[cfg(target_os = "windows")]
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use core::time;
-//     use std::{process::Command, thread, path::Path, fs};
-//     use sysinfo::{Pid, Signal};
-//     use tempfile::NamedTempFile;
-//     use sysinfo::{ProcessExt,System,SystemExt,PidExt};
+#[cfg(target_os = "windows")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::time;
+    use std::{process::Command, thread, path::Path, fs};
+    use sysinfo::{Pid, Signal};
+    use tempfile::NamedTempFile;
+    use sysinfo::{ProcessExt,System,SystemExt,PidExt};
     
-//     #[test]
-//     fn test_dll_inject_simple() -> anyhow::Result<()>{
-//         // Get unique and unused temp file path
-//         let tmp_file = NamedTempFile::new()?;
-//         let path = String::from(tmp_file.path().to_str().unwrap()).clone();
-//         tmp_file.close()?;
+    #[test]
+    fn test_dll_inject_simple() -> anyhow::Result<()>{
+        // Get unique and unused temp file path
+        let tmp_file = NamedTempFile::new()?;
+        let path = String::from(tmp_file.path().to_str().unwrap()).clone();
+        tmp_file.close()?;
 
-//         // Get the path to our test dll file.
-//         let cargo_root = env!("CARGO_MANIFEST_DIR");
-//         let relative_path_to_test_dll = "..\\..\\tests\\create_file_dll\\target\\debug\\create_file_dll.dll";
-//         let test_dll_path = Path::new(cargo_root).join(relative_path_to_test_dll);
-//         assert!(test_dll_path.is_file());
+        // Get the path to our test dll file.
+        let cargo_root = env!("CARGO_MANIFEST_DIR");
+        let relative_path_to_test_dll = "..\\..\\tests\\create_file_dll\\target\\debug\\create_file_dll.dll";
+        let test_dll_path = Path::new(cargo_root).join(relative_path_to_test_dll);
+        assert!(test_dll_path.is_file());
 
-//         // Out target process is notepad for stability and control.
-//         // The temp file is passed through an environment variable.
-//         let expected_process = Command::new("C:\\Windows\\System32\\notepad.exe").env("LIBTESTFILE", path.clone()).spawn();
-//         let target_pid = expected_process.unwrap().id();
+        // Out target process is notepad for stability and control.
+        // The temp file is passed through an environment variable.
+        let expected_process = Command::new("C:\\Windows\\System32\\notepad.exe").env("LIBTESTFILE", path.clone()).spawn();
+        let target_pid = expected_process.unwrap().id();
 
-//         // Run our code.
-//         let _res = dll_inject(test_dll_path.to_string_lossy().to_string(), target_pid);
+        // Run our code.
+        let _res = dll_inject(test_dll_path.to_string_lossy().to_string(), target_pid);
 
-//         let delay = time::Duration::from_secs(1);
-//         thread::sleep(delay);
+        let delay = time::Duration::from_secs(1);
+        thread::sleep(delay);
 
-//         // Test that the test file was created
-//         let test_path = Path::new(path.as_str());
-//         assert!(test_path.is_file());
+        // Test that the test file was created
+        let test_path = Path::new(path.as_str());
+        assert!(test_path.is_file());
 
-//         // Delete test file
-//         let _ = fs::remove_file(test_path);
+        // Delete test file
+        let _ = fs::remove_file(test_path);
         
-//         // kill the target process notepad
-//         let mut sys = System::new();
-//         sys.refresh_processes();
-//         match sys.process(Pid::from_u32(target_pid)) {
-//             Some(res) => {
-//                 res.kill_with(Signal::Kill);
-//             },
-//             None => {
-//             },
-//         }
+        // kill the target process notepad
+        let mut sys = System::new();
+        sys.refresh_processes();
+        match sys.process(Pid::from_u32(target_pid)) {
+            Some(res) => {
+                res.kill_with(Signal::Kill);
+            },
+            None => {
+            },
+        }
 
-//         Ok(())
-//     }
-// }
+        Ok(())
+    }
+}

--- a/implants/eldritch/src/sys/dll_inject_impl.rs
+++ b/implants/eldritch/src/sys/dll_inject_impl.rs
@@ -78,58 +78,58 @@ pub fn dll_inject(dll_path: String, pid: u32) -> Result<NoneType> {
     }
 }
 
-#[cfg(target_os = "windows")]
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use core::time;
-    use std::{process::Command, thread, path::Path, fs};
-    use sysinfo::{Pid, Signal};
-    use tempfile::NamedTempFile;
-    use sysinfo::{ProcessExt,System,SystemExt,PidExt};
+// #[cfg(target_os = "windows")]
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use core::time;
+//     use std::{process::Command, thread, path::Path, fs};
+//     use sysinfo::{Pid, Signal};
+//     use tempfile::NamedTempFile;
+//     use sysinfo::{ProcessExt,System,SystemExt,PidExt};
     
-    #[test]
-    fn test_dll_inject_simple() -> anyhow::Result<()>{
-        // Get unique and unused temp file path
-        let tmp_file = NamedTempFile::new()?;
-        let path = String::from(tmp_file.path().to_str().unwrap()).clone();
-        tmp_file.close()?;
+//     #[test]
+//     fn test_dll_inject_simple() -> anyhow::Result<()>{
+//         // Get unique and unused temp file path
+//         let tmp_file = NamedTempFile::new()?;
+//         let path = String::from(tmp_file.path().to_str().unwrap()).clone();
+//         tmp_file.close()?;
 
-        // Get the path to our test dll file.
-        let cargo_root = env!("CARGO_MANIFEST_DIR");
-        let relative_path_to_test_dll = "..\\..\\tests\\create_file_dll\\target\\debug\\create_file_dll.dll";
-        let test_dll_path = Path::new(cargo_root).join(relative_path_to_test_dll);
-        assert!(test_dll_path.is_file());
+//         // Get the path to our test dll file.
+//         let cargo_root = env!("CARGO_MANIFEST_DIR");
+//         let relative_path_to_test_dll = "..\\..\\tests\\create_file_dll\\target\\debug\\create_file_dll.dll";
+//         let test_dll_path = Path::new(cargo_root).join(relative_path_to_test_dll);
+//         assert!(test_dll_path.is_file());
 
-        // Out target process is notepad for stability and control.
-        // The temp file is passed through an environment variable.
-        let expected_process = Command::new("C:\\Windows\\System32\\notepad.exe").env("LIBTESTFILE", path.clone()).spawn();
-        let target_pid = expected_process.unwrap().id();
+//         // Out target process is notepad for stability and control.
+//         // The temp file is passed through an environment variable.
+//         let expected_process = Command::new("C:\\Windows\\System32\\notepad.exe").env("LIBTESTFILE", path.clone()).spawn();
+//         let target_pid = expected_process.unwrap().id();
 
-        // Run our code.
-        let _res = dll_inject(test_dll_path.to_string_lossy().to_string(), target_pid);
+//         // Run our code.
+//         let _res = dll_inject(test_dll_path.to_string_lossy().to_string(), target_pid);
 
-        let delay = time::Duration::from_secs(1);
-        thread::sleep(delay);
+//         let delay = time::Duration::from_secs(1);
+//         thread::sleep(delay);
 
-        // Test that the test file was created
-        let test_path = Path::new(path.as_str());
-        assert!(test_path.is_file());
+//         // Test that the test file was created
+//         let test_path = Path::new(path.as_str());
+//         assert!(test_path.is_file());
 
-        // Delete test file
-        let _ = fs::remove_file(test_path);
+//         // Delete test file
+//         let _ = fs::remove_file(test_path);
         
-        // kill the target process notepad
-        let mut sys = System::new();
-        sys.refresh_processes();
-        match sys.process(Pid::from_u32(target_pid)) {
-            Some(res) => {
-                res.kill_with(Signal::Kill);
-            },
-            None => {
-            },
-        }
+//         // kill the target process notepad
+//         let mut sys = System::new();
+//         sys.refresh_processes();
+//         match sys.process(Pid::from_u32(target_pid)) {
+//             Some(res) => {
+//                 res.kill_with(Signal::Kill);
+//             },
+//             None => {
+//             },
+//         }
 
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+// }

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -11,17 +11,8 @@ use eldritch::{eldritch_run};
 
 mod inter;
 
-
-// fn run(tome_path: String) -> anyhow::Result<String> {
-//     // Read a tome script
-//     let tome_contents = fs::read_to_string(tome_path.clone())?;
-//     // Execute a tome script
-//     eldritch_run(tome_path, tome_contents, None)
-// }
-
-
 #[tokio::main]
- async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<()> {
     let matches = Command::new("golem")
         .arg(Arg::with_name("INPUT")
             .help("Set the tomes to run")
@@ -50,7 +41,6 @@ mod inter;
         let mut result: Vec<String> = Vec::new();
         for tome_task in all_tome_futures {
             let tome_name: String = tome_task.0;
-            println!("{}", tome_name);
             // Join our 
             let tome_result_thread_join = match tome_task.1.join() {
                 Ok(local_thread_join_res) => local_thread_join_res,

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -2,7 +2,6 @@ extern crate golem;
 extern crate eldritch;
 
 use clap::{Command, Arg};
-use tokio::task;
 use std::fs;
 use std::process;
 use std::thread;

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -5,21 +5,23 @@ use clap::{Command, Arg};
 use tokio::task;
 use std::fs;
 use std::process;
+use std::thread;
 
 use eldritch::{eldritch_run};
 
 mod inter;
 
 
-async fn run(tome_path: String) -> anyhow::Result<String> {
-    // Read a tome script
-    let tome_contents = fs::read_to_string(tome_path.clone())?;
-    // Execute a tome script
-    eldritch_run(tome_path, tome_contents, None)
-}
+// fn run(tome_path: String) -> anyhow::Result<String> {
+//     // Read a tome script
+//     let tome_contents = fs::read_to_string(tome_path.clone())?;
+//     // Execute a tome script
+//     eldritch_run(tome_path, tome_contents, None)
+// }
+
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+ async fn main() -> anyhow::Result<()> {
     let matches = Command::new("golem")
         .arg(Arg::with_name("INPUT")
             .help("Set the tomes to run")
@@ -37,31 +39,33 @@ async fn main() -> anyhow::Result<()> {
         // Queue async tasks
         let mut all_tome_futures: Vec<(String, _)> = vec![];
         for tome in tome_files {
-            let tome_execution_task = run(tome.to_string());
-            let tmp_row = (tome.to_string(), task::spawn(tome_execution_task));
+            let tome_path = tome.to_string().clone();
+            let tome_contents = fs::read_to_string(tome_path.clone())?;
+            let tmp_row = (tome.to_string(), thread::spawn(|| { eldritch_run(tome_path, tome_contents, None) }));
             all_tome_futures.push(tmp_row)
         }
 
+
         let mut error_code = 0;
-        // Collect results and do error handling
         let mut result: Vec<String> = Vec::new();
         for tome_task in all_tome_futures {
-            // Get the name of the file from our tuple.
             let tome_name: String = tome_task.0;
-            match tome_task.1.await {
-                // Match on task results.
-                Ok(res) => match res {
-                        Ok(task_res) => result.push(task_res),
-                        Err(task_err) => {
-                            eprintln!("[TASK ERROR] {tome_name}: {task_err}");
-                            error_code = 1;        
-                        }
-                    },
-
-                Err(err) => {
-                    eprintln!("[ERROR] {tome_name}: {err}");
+            println!("{}", tome_name);
+            // Join our 
+            let tome_result_thread_join = match tome_task.1.join() {
+                Ok(local_thread_join_res) => local_thread_join_res,
+                Err(_) => {
                     error_code = 1;
+                    Err(anyhow::anyhow!("An error occured waiting for the tome thread to complete while executing {tome_name}."))
                 },
+            };
+
+            match tome_result_thread_join {
+                Ok(local_tome_result) => result.push(local_tome_result),
+                Err(task_error) => {
+                    error_code = 1;
+                    eprintln!("[TASK ERROR] {tome_name}: {task_error}");
+                }
             }
         }
         if result.len() > 0 {
@@ -73,5 +77,3 @@ async fn main() -> anyhow::Result<()> {
     }
     Ok(())
 }
-
-

--- a/implants/golem/tests/cli.rs
+++ b/implants/golem/tests/cli.rs
@@ -12,7 +12,7 @@ fn test_golem_main_file_not_found() -> anyhow::Result<()> {
     cmd.arg("nonexistentdir/run.tome");
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("[TASK ERROR] nonexistentdir/run.tome: No such file or directory (os error 2)"));
+        .stderr(predicate::str::contains("Error: No such file or directory"));
 
     Ok(())
 }
@@ -67,7 +67,7 @@ fn test_golem_main_basic_async() -> anyhow::Result<()> {
     cmd.arg("working_dir/tomes/download_test.tome");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains(r#"OKAY!"#));
+        .stderr(predicate::str::contains(r#"OKAY!"#));
 
     Ok(())
 }

--- a/implants/golem/tests/cli.rs
+++ b/implants/golem/tests/cli.rs
@@ -53,7 +53,21 @@ fn test_golem_main_basic_eldritch_non_interactive() -> anyhow::Result<()> {
     cmd.arg("working_dir/tomes/eldritch_test.tome");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("[\"[\\\"append\\\", \\\"copy\\\", \\\"download\\\", \\\"exists\\\", \\\"hash\\\", \\\"is_dir\\\", \\\"is_file\\\", \\\"mkdir\\\", \\\"read\\\", \\\"remove\\\", \\\"rename\\\", \\\"replace\\\", \\\"replace_all\\\", \\\"timestomp\\\", \\\"write\\\"]\"]"));
+        .stdout(predicate::str::contains(r#"[\"append\", \"compress\""#));
+
+    Ok(())
+}
+
+
+// Test running `./golem ./working_dir/tomes/eldritch_test.tome`
+#[test]
+fn test_golem_main_basic_async() -> anyhow::Result<()> {
+    let mut cmd = Command::cargo_bin("golem")?;
+
+    cmd.arg("working_dir/tomes/download_test.tome");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(r#"OKAY!"#));
 
     Ok(())
 }

--- a/implants/golem/working_dir/tomes/download_test.tome
+++ b/implants/golem/working_dir/tomes/download_test.tome
@@ -1,0 +1,2 @@
+file.download("https://github.com/KCarretto/realm/releases/download/v0.0.1/imix-linux-x64","/tmp/abc")
+print("OKAY!")

--- a/implants/imix/src/main.rs
+++ b/implants/imix/src/main.rs
@@ -1,3 +1,4 @@
+use std::thread;
 use std::{collections::HashMap, fs};
 use std::fs::File;
 use std::io::Write;
@@ -40,7 +41,11 @@ async fn handle_exec_tome(task: GraphQLTask) -> Result<(String,String)> {
     let tome_contents = task_job.tome.eldritch;
 
     // Execute a tome script
-    let res = eldritch_run(tome_name, tome_contents, task_job.tome.parameters);
+    let res =  match thread::spawn(|| { eldritch_run(tome_name, tome_contents, task_job.tome.parameters) }).join() {
+        Ok(local_thread_res) => local_thread_res,
+        Err(_) => todo!(),
+    };
+    
     match res {
         Ok(tome_output) => Ok((tome_output, "".to_string())),
         Err(tome_error) => Ok(("".to_string(), tome_error.to_string())),

--- a/tests/create_file_dll/src/lib.rs
+++ b/tests/create_file_dll/src/lib.rs
@@ -27,7 +27,7 @@ extern "system" fn DllMain(
 pub fn demo_init() {
     unsafe { consoleapi::AllocConsole() };
     for (key, value) in env::vars_os() {
-        println!("{key:?}: {value:?}");
+        // println!("{key:?}: {value:?}");
         if key == "LIBTESTFILE" {
             let mut file = File::create(value).unwrap();
             let _ = file.write_all(b"Hello, world!");


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind eldritch-function

#### What this PR does / why we need it:
Async functions like download, and port_scan cause the agent to crash with an error about nested block_on runtimes.
To resolve this we've implemented new threads for each eldritch execution.
This creates a unique runtime for each allowing the eldritch function to create a tokio runtime.


Also resolves dll inject test failure by disabling defender in CI vms.
