### PR TITLE
Improved error message on parameters decode and "" case.

### DIFF
--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -72,7 +72,10 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
     }
 
     let tome_params_str: String = match tome_parameters {
-        Some(param_string) => param_string,
+        Some(local_param_string) => match local_param_string.as_str() {
+            "" => "{}".to_string(), // If we get "" as our params update it to "{}"
+            _ => local_param_string // Otherwise return our string.
+        },
         None => "{}".to_string(),
     };
 
@@ -83,7 +86,11 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
     let res: SmallMap<Value, Value> = SmallMap::new();
     let mut input_params: Dict = Dict::new(res);
     
-    let parsed: serde_json::Value = serde_json::from_str(&tome_params_str)?;
+    let parsed: serde_json::Value = match serde_json::from_str(&tome_params_str){
+        Ok(local_value) => local_value,
+        Err(local_err) => return Err(anyhow::anyhow!("[imix] error decoding tome_params to JSON: {}: {}", local_err.to_string(), tome_params_str)),
+    };
+
     let param_map: serde_json::Map<String, serde_json::Value> = match parsed.as_object() {
         Some(tmp_param_map) => tmp_param_map.clone(),
         None => Map::new(),

--- a/implants/eldritch/src/lib.rs
+++ b/implants/eldritch/src/lib.rs
@@ -67,7 +67,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
             &Dialect::Standard
         ) {
             Ok(res) => res,
-            Err(err) => return Err(anyhow::anyhow!("[imix] Unable to parse eldritch tome: {}: {} {}", err.to_string(), tome_filename.as_str(), tome_contents.as_str())),
+            Err(err) => return Err(anyhow::anyhow!("[eldritch] Unable to parse eldritch tome: {}: {} {}", err.to_string(), tome_filename.as_str(), tome_contents.as_str())),
     };
 
     let tome_params_str: String = match tome_parameters {
@@ -80,7 +80,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
 
     let globals = match get_eldritch() {
         Ok(local_globals) => local_globals,
-        Err(local_error) => return Err(anyhow::anyhow!("[imix] Failed to get_eldritch globals: {}", local_error.to_string())),
+        Err(local_error) => return Err(anyhow::anyhow!("[eldritch] Failed to get_eldritch globals: {}", local_error.to_string())),
     };
 
     let module: Module = Module::new();
@@ -90,7 +90,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
     
     let parsed: serde_json::Value = match serde_json::from_str(&tome_params_str){
         Ok(local_value) => local_value,
-        Err(local_err) => return Err(anyhow::anyhow!("[imix] error decoding tome_params to JSON: {}: {}", local_err.to_string(), tome_params_str)),
+        Err(local_err) => return Err(anyhow::anyhow!("[eldritch] Error decoding tome_params to JSON: {}: {}", local_err.to_string(), tome_params_str)),
     };
 
     let param_map: serde_json::Map<String, serde_json::Value> = match parsed.as_object() {
@@ -136,7 +136,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
         }
         let hashed_key = match new_key.to_value().get_hashed() {
             Ok(local_hashed_key) => local_hashed_key,
-            Err(local_error) => return Err(anyhow::anyhow!("[imix] Failed to create hashed key for key {}: {}", new_key.to_string(), local_error.to_string())),
+            Err(local_error) => return Err(anyhow::anyhow!("[eldritch] Failed to create hashed key for key {}: {}", new_key.to_string(), local_error.to_string())),
         };
         input_params.insert_hashed(hashed_key, new_value);
     }
@@ -148,7 +148,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
 
     let res: Value = match eval.eval_module(ast, &globals) {
         Ok(eval_val) => eval_val,
-        Err(eval_error) => return Err(anyhow::anyhow!("[imix] Eldritch eval_module failed:\n{}", eval_error)),
+        Err(eval_error) => return Err(anyhow::anyhow!("[eldritch] Eldritch eval_module failed:\n{}", eval_error)),
     };
 
     Ok(res.to_str())

--- a/implants/golem/tests/cli.rs
+++ b/implants/golem/tests/cli.rs
@@ -30,7 +30,7 @@ fn test_golem_main_syntax_fail() -> anyhow::Result<()> {
     cmd.arg("../../tests/golem_cli_test/syntax_fail.tome");
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("[TASK ERROR] ../../tests/golem_cli_test/syntax_fail.tome: error: Parse error: unexpected string literal 'win' here"));
+        .stderr(predicate::str::contains("[TASK ERROR] ../../tests/golem_cli_test/syntax_fail.tome: [eldritch] Unable to parse eldritch tome: error: Parse error: unexpected string literal \'win\' here"));
 
     Ok(())
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
This adds support for the case where parameters = "" this is the value when parameters is not specified by the c2 server.

Also adds improved error handling around parameter decoding.
<img width="886" alt="image" src="https://github.com/KCarretto/realm/assets/7121375/c5269b8c-0b52-467a-9e76-10513e261632">

This PR also adds error handling around other uses of `?` in eldritch_run to better show why tomes fail and hopefully speed up trouble shooting in the future.

#### Which issue(s) this PR fixes:
Fixes #221 
