### PR TITLE
Add codecov config to delay PR comment

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    wait_for_ci: yes


### PR DESCRIPTION
Hopefully will prevent PR comments that cause -20% code coverage since CI pipelines haven't submitted their reports yet.