### PR TITLE
Update starlark

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -7,8 +7,8 @@ members = [
 ]
 
 [workspace.dependencies]
-allocative = { git = "https://github.com/facebookexperimental/starlark-rust", rev = "acf638430a00ca3855862e8c669670e1adaa42aa" }
-allocative_derive = { git = "https://github.com/facebookexperimental/starlark-rust", rev = "acf638430a00ca3855862e8c669670e1adaa42aa" }
+allocative = { git = "https://github.com/facebookexperimental/starlark-rust", rev = "1109aaf9b700d7cdd7ba48986aa650221b70a22f" }
+allocative_derive = { git = "https://github.com/facebookexperimental/starlark-rust", rev = "1109aaf9b700d7cdd7ba48986aa650221b70a22f" }
 anyhow = "1.0.65"
 assert_cmd = "2.0.6"
 async-recursion = "1.0.0"
@@ -38,7 +38,8 @@ rust-embed = "6.6.0"
 serde = "1.0"
 serde_json = "1.0.87"
 sha256 = "1.0.3"
-starlark = { git = "https://github.com/facebookexperimental/starlark-rust", rev = "acf638430a00ca3855862e8c669670e1adaa42aa" }
+starlark = { git = "https://github.com/facebookexperimental/starlark-rust", rev = "1109aaf9b700d7cdd7ba48986aa650221b70a22f" }
+starlark_derive = { git = "https://github.com/facebookexperimental/starlark-rust", rev = "1109aaf9b700d7cdd7ba48986aa650221b70a22f" }
 structopt = "0.3.23"
 sys-info = "0.9.1"
 sysinfo = "0.28.4"

--- a/implants/golem/src/inter.rs
+++ b/implants/golem/src/inter.rs
@@ -99,7 +99,7 @@ fn drain(xs: impl Iterator<Item = EvalMessage>, json: bool, stats: &mut Stats) {
 }
 
 fn interactive(ctx: &Context) -> anyhow::Result<()> {
-    let mut rl = ReadLine::new("STARLARK_RUST_HISTFILE");
+    let mut rl = ReadLine::new("STARLARK_RUST_HISTFILE")?;
     loop {
         match rl.read_line("$> ")? {
             Some(line) => {

--- a/implants/golem/src/inter/eval.rs
+++ b/implants/golem/src/inter/eval.rs
@@ -31,6 +31,7 @@
  use starlark::docs::render_docs_as_code;
  use starlark::docs::Doc;
  use starlark::docs::DocItem;
+ use starlark::docs::DocModule;
  use starlark::environment::FrozenModule;
  use starlark::environment::Globals;
  use starlark::environment::Module;
@@ -136,15 +137,17 @@
      }
  
      fn url_for_doc(doc: &Doc) -> LspUrl {
-         let url = match &doc.item {
-             DocItem::Module(_) => Url::parse("starlark:/native/builtins.bzl").unwrap(),
-             DocItem::Object(_) => {
-                 Url::parse(&format!("starlark:/native/builtins/{}.bzl", doc.id.name)).unwrap()
-             }
-             DocItem::Function(_) => Url::parse("starlark:/native/builtins.bzl").unwrap(),
-         };
-         LspUrl::try_from(url).unwrap()
-     }
+        let url = match &doc.item {
+            DocItem::Module(_) => Url::parse("starlark:/native/builtins.bzl").unwrap(),
+            DocItem::Object(_) => {
+                Url::parse(&format!("starlark:/native/builtins/{}.bzl", doc.id.name)).unwrap()
+            }
+            DocItem::Function(_) | DocItem::Property(_) => {
+                Url::parse("starlark:/native/builtins.bzl").unwrap()
+            }
+        };
+        LspUrl::try_from(url).unwrap()
+    }
  
      fn new_module(prelude: &[FrozenModule]) -> Module {
          let module = Module::new();
@@ -273,51 +276,58 @@
      }
  }
  
- impl LspContext for Context {
-     fn parse_file_with_contents(&self, uri: &LspUrl, content: String) -> LspEvalResult {
-         match uri {
-             LspUrl::File(uri) => {
-                 let EvalResult { messages, ast } =
-                     self.file_with_contents(&uri.to_string_lossy(), content);
-                 LspEvalResult {
-                     diagnostics: messages.map(Diagnostic::from).collect(),
-                     ast,
-                 }
-             }
-             _ => LspEvalResult::default(),
-         }
-     }
+impl LspContext for Context {
+    fn parse_file_with_contents(&self, uri: &LspUrl, content: String) -> LspEvalResult {
+        match uri {
+            LspUrl::File(uri) => {
+                let EvalResult { messages, ast } =
+                    self.file_with_contents(&uri.to_string_lossy(), content);
+                LspEvalResult {
+                    diagnostics: messages.map(Diagnostic::from).collect(),
+                    ast,
+                }
+            }
+            _ => LspEvalResult::default(),
+        }
+    }
  
-     fn resolve_load(&self, path: &str, current_file: &LspUrl) -> anyhow::Result<LspUrl> {
-         let path = PathBuf::from(path);
-         match current_file {
-             LspUrl::File(current_file_path) => {
-                 let current_file_dir = current_file_path.parent();
-                 let absolute_path = match (current_file_dir, path.is_absolute()) {
-                     (_, true) => Ok(path),
-                     (Some(current_file_dir), false) => Ok(current_file_dir.join(&path)),
-                     (None, false) => Err(ResolveLoadError::MissingCurrentFilePath(path)),
-                 }?;
-                 Ok(Url::from_file_path(absolute_path).unwrap().try_into()?)
-             }
-             _ => Err(
-                 ResolveLoadError::WrongScheme("file://".to_owned(), current_file.clone()).into(),
-             ),
-         }
-     }
+     fn resolve_load(
+        &self,
+        path: &str,
+        current_file: &LspUrl,
+        _workspace_root: Option<&Path>,
+    ) -> anyhow::Result<LspUrl> {
+        let path = PathBuf::from(path);
+        match current_file {
+            LspUrl::File(current_file_path) => {
+                let current_file_dir = current_file_path.parent();
+                let absolute_path = match (current_file_dir, path.is_absolute()) {
+                    (_, true) => Ok(path),
+                    (Some(current_file_dir), false) => Ok(current_file_dir.join(&path)),
+                    (None, false) => Err(ResolveLoadError::MissingCurrentFilePath(path)),
+                }?;
+                Ok(Url::from_file_path(absolute_path).unwrap().try_into()?)
+            }
+            _ => Err(
+                ResolveLoadError::WrongScheme("file://".to_owned(), current_file.clone()).into(),
+            ),
+        }
+    }
  
      fn resolve_string_literal(
-         &self,
-         literal: &str,
-         current_file: &LspUrl,
-     ) -> anyhow::Result<Option<StringLiteralResult>> {
-         self.resolve_load(literal, current_file).map(|url| {
-             Some(StringLiteralResult {
-                 url,
-                 location_finder: None,
-             })
-         })
-     }
+        &self,
+        literal: &str,
+        current_file: &LspUrl,
+        workspace_root: Option<&Path>,
+    ) -> anyhow::Result<Option<StringLiteralResult>> {
+        self.resolve_load(literal, current_file, workspace_root)
+            .map(|url| {
+                Some(StringLiteralResult {
+                    url,
+                    location_finder: None,
+                })
+            })
+    }
  
      fn get_load_contents(&self, uri: &LspUrl) -> anyhow::Result<Option<String>> {
          match uri {
@@ -341,6 +351,19 @@
      ) -> anyhow::Result<Option<LspUrl>> {
          Ok(self.builtin_symbols.get(symbol).cloned())
      }
+
+     fn render_as_load(
+        &self,
+        _target: &LspUrl,
+        _current_file: &LspUrl,
+        _workspace_root: Option<&Path>,
+    ) -> anyhow::Result<String> {
+        Err(anyhow::anyhow!("Not yet implemented, render_as_load"))
+    }
+
+    fn get_environment(&self, _uri: &LspUrl) -> DocModule {
+        DocModule::default()
+    }
  }
  
  pub(crate) fn globals() -> Globals {

--- a/implants/golem/tests/cli.rs
+++ b/implants/golem/tests/cli.rs
@@ -30,7 +30,7 @@ fn test_golem_main_syntax_fail() -> anyhow::Result<()> {
     cmd.arg("../../tests/golem_cli_test/syntax_fail.tome");
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("[TASK ERROR] ../../tests/golem_cli_test/syntax_fail.tome: [eldritch] Unable to parse eldritch tome: error: Parse error: unexpected string literal \'win\' here"));
+        .stderr(predicate::str::contains("[TASK ERROR] ../../tests/golem_cli_test/syntax_fail.tome: [eldritch] Unable to parse eldritch tome: error: Parse error: unexpected string literal \"win\" here"));
 
     Ok(())
 }

--- a/implants/lib/eldritch/src/assets.rs
+++ b/implants/lib/eldritch/src/assets.rs
@@ -30,6 +30,7 @@ pub struct Asset;
 pub struct AssetsLibrary();
 starlark_simple_value!(AssetsLibrary);
 
+#[allow(non_upper_case_globals)]
 #[starlark_value(type = "assets_library")]
 impl<'v> StarlarkValue<'v> for AssetsLibrary {
     fn get_methods() -> Option<&'static Methods> {

--- a/implants/lib/eldritch/src/assets.rs
+++ b/implants/lib/eldritch/src/assets.rs
@@ -8,8 +8,8 @@ use derive_more::Display;
 
 use starlark::environment::{Methods, MethodsBuilder, MethodsStatic};
 use starlark::values::none::NoneType;
-use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType};
-use starlark::{starlark_type, starlark_simple_value, starlark_module};
+use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType, starlark_value};
+use starlark::{starlark_simple_value, starlark_module};
 
 use serde::{Serialize,Serializer};
 use rust_embed::RustEmbed;
@@ -30,9 +30,8 @@ pub struct Asset;
 pub struct AssetsLibrary();
 starlark_simple_value!(AssetsLibrary);
 
+#[starlark_value(type = "assets_library")]
 impl<'v> StarlarkValue<'v> for AssetsLibrary {
-    starlark_type!("assets_library");
-
     fn get_methods() -> Option<&'static Methods> {
         static RES: MethodsStatic = MethodsStatic::new();
         RES.methods(methods)

--- a/implants/lib/eldritch/src/file.rs
+++ b/implants/lib/eldritch/src/file.rs
@@ -17,8 +17,6 @@ mod template_impl;
 mod timestomp_impl;
 mod write_impl;
 
-use std::fmt;
-
 use allocative::Allocative;
 use derive_more::Display;
 

--- a/implants/lib/eldritch/src/file.rs
+++ b/implants/lib/eldritch/src/file.rs
@@ -26,8 +26,8 @@ use starlark::values::dict::Dict;
 use starlark::collections::SmallMap;
 use starlark::environment::{Methods, MethodsBuilder, MethodsStatic};
 use starlark::values::none::NoneType;
-use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType, Heap};
-use starlark::{starlark_type, starlark_simple_value, starlark_module};
+use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType, Heap, starlark_value};
+use starlark::{starlark_simple_value, starlark_module};
 use serde::{Serialize,Serializer};
 
 #[derive(Copy, Clone, Debug, PartialEq, Display, ProvidesStaticType, Allocative)]
@@ -35,8 +35,8 @@ use serde::{Serialize,Serializer};
 pub struct FileLibrary();
 starlark_simple_value!(FileLibrary);
 
+#[starlark_value(type = "file_library")]
 impl<'v> StarlarkValue<'v> for FileLibrary {
-    starlark_type!("file_library");
 
     fn get_methods() -> Option<&'static Methods> {
         static RES: MethodsStatic = MethodsStatic::new();

--- a/implants/lib/eldritch/src/file.rs
+++ b/implants/lib/eldritch/src/file.rs
@@ -33,6 +33,7 @@ use serde::{Serialize,Serializer};
 pub struct FileLibrary();
 starlark_simple_value!(FileLibrary);
 
+#[allow(non_upper_case_globals)]
 #[starlark_value(type = "file_library")]
 impl<'v> StarlarkValue<'v> for FileLibrary {
 

--- a/implants/lib/eldritch/src/file/list_impl.rs
+++ b/implants/lib/eldritch/src/file/list_impl.rs
@@ -132,7 +132,7 @@ fn create_dict_from_file(starlark_heap: &Heap, file: File) -> Result<Dict>{
     tmp_res.insert_hashed(const_frozen_string!("file_name").to_value().get_hashed().unwrap(), tmp_value1.to_value());
 
     let file_size = file.size as i32;
-    tmp_res.insert_hashed(const_frozen_string!("size").to_value().get_hashed().unwrap(), Value::new_int(file_size));
+    tmp_res.insert_hashed(const_frozen_string!("size").to_value().get_hashed().unwrap(), starlark_heap.alloc(file_size));
 
     let tmp_value2 = starlark_heap.alloc_str(&file.owner);
     tmp_res.insert_hashed(const_frozen_string!("owner").to_value().get_hashed().unwrap(), tmp_value2.to_value());

--- a/implants/lib/eldritch/src/file/template_impl.rs
+++ b/implants/lib/eldritch/src/file/template_impl.rs
@@ -25,7 +25,7 @@ pub fn template(template_path: String, dst_path: String, args: SmallMap<String, 
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use starlark::{collections::SmallMap, values::FrozenHeap};
+    use starlark::{collections::SmallMap, values::{FrozenHeap, Heap}};
     use tempfile::NamedTempFile;
     use starlark::const_frozen_string;
 
@@ -33,9 +33,10 @@ mod tests {
 
     #[test]
     fn test_template_build_context() -> anyhow::Result<()>{
+        let heap = Heap::new();
         let mut map: SmallMap<String, Value> = SmallMap::new();
         map.insert("name".to_string(), const_frozen_string!("greg").to_value());
-        map.insert("age".to_string(), Value::new_int(29));
+        map.insert("age".to_string(), heap.alloc(29));
         map.insert("admin".to_string(), Value::new_bool(true));
 
         let res = build_context(map)?;
@@ -51,6 +52,8 @@ mod tests {
         let dst_path = String::from(tmp_file.path().to_str().unwrap());
         dst_tmp_file.close()?;
 
+        let heap = Heap::new();
+
         // Write out template
         fs::write(path.clone(),
 r#"Hello {{ name }},
@@ -61,7 +64,7 @@ Congratulations on making it that far.
         // Setup our args
         let mut dict_data: SmallMap<String, Value> = SmallMap::new();
         dict_data.insert("name".to_string(), const_frozen_string!("test123").to_value());
-        dict_data.insert("age".to_string(), Value::new_int(22));
+        dict_data.insert("age".to_string(), heap.alloc(22));
 
         // Run our code
         template(path, dst_path.clone(), dict_data, true)?;

--- a/implants/lib/eldritch/src/lib.rs
+++ b/implants/lib/eldritch/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc::{Sender};
 use serde_json::Map;
 use starlark::collections::SmallMap;
 use starlark::{starlark_module, PrintHandler};
-use starlark::environment::{GlobalsBuilder, Module, Globals};
+use starlark::environment::{GlobalsBuilder, Module, Globals, LibraryExtension};
 use starlark::syntax::{AstModule, Dialect};
 use starlark::eval::Evaluator;
 use starlark::values::dict::Dict;
@@ -30,7 +30,25 @@ pub fn get_eldritch() -> anyhow::Result<Globals> {
         const assets: AssetsLibrary = AssetsLibrary();
     }
 
-    let globals = GlobalsBuilder::standard().with(eldritch).build();
+    // let extended_globals = Globals::extended_internal();
+    // let globals = GlobalsBuilder::new().with(eldritch).build();
+    let globals = GlobalsBuilder::extended_by(
+        &[
+            LibraryExtension::StructType,
+            LibraryExtension::RecordType,
+            LibraryExtension::EnumType,
+            LibraryExtension::Map,
+            LibraryExtension::Filter,
+            LibraryExtension::Partial,
+            LibraryExtension::ExperimentalRegex,
+            LibraryExtension::Debug,
+            LibraryExtension::Print,
+            LibraryExtension::Breakpoint,
+            LibraryExtension::Json,
+            LibraryExtension::Abs,
+            LibraryExtension::Typing,
+        ]
+    ).with(eldritch).build();
     return Ok(globals);
 }
 
@@ -64,7 +82,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
     let ast =  match AstModule::parse(
             &tome_filename,
             tome_contents.as_str().to_owned(),
-            &Dialect::Standard
+            &Dialect::Extended
         ) {
             Ok(res) => res,
             Err(err) => return Err(anyhow::anyhow!("[eldritch] Unable to parse eldritch tome: {}: {} {}", err.to_string(), tome_filename.as_str(), tome_contents.as_str())),

--- a/implants/lib/eldritch/src/lib.rs
+++ b/implants/lib/eldritch/src/lib.rs
@@ -12,7 +12,7 @@ use starlark::environment::{GlobalsBuilder, Module, Globals};
 use starlark::syntax::{AstModule, Dialect};
 use starlark::eval::Evaluator;
 use starlark::values::dict::Dict;
-use starlark::values::{Value, AllocValue};
+use starlark::values::{Value, AllocValue, FrozenValue};
 
 use file::FileLibrary;
 use process::ProcessLibrary;
@@ -30,7 +30,7 @@ pub fn get_eldritch() -> anyhow::Result<Globals> {
         const assets: AssetsLibrary = AssetsLibrary();
     }
 
-    let globals = GlobalsBuilder::extended().with(eldritch).build();
+    let globals = GlobalsBuilder::standard().with(eldritch).build();
     return Ok(globals);
 }
 
@@ -132,7 +132,7 @@ pub fn eldritch_run(tome_filename: String, tome_contents: String, tome_parameter
                 },
                 None => i32::MAX.into(),
             };
-            new_value = Value::new_int(tmp_value);
+            new_value = module.heap().alloc(tmp_value);
         }
         let hashed_key = match new_key.to_value().get_hashed() {
             Ok(local_hashed_key) => local_hashed_key,

--- a/implants/lib/eldritch/src/lib.rs
+++ b/implants/lib/eldritch/src/lib.rs
@@ -4,7 +4,7 @@ pub mod sys;
 pub mod pivot;
 pub mod assets;
 
-use std::sync::mpsc::{Sender};
+use std::sync::mpsc::Sender;
 use serde_json::Map;
 use starlark::collections::SmallMap;
 use starlark::{starlark_module, PrintHandler};
@@ -12,7 +12,7 @@ use starlark::environment::{GlobalsBuilder, Module, Globals, LibraryExtension};
 use starlark::syntax::{AstModule, Dialect};
 use starlark::eval::Evaluator;
 use starlark::values::dict::Dict;
-use starlark::values::{Value, AllocValue, FrozenValue};
+use starlark::values::{Value, AllocValue};
 
 use file::FileLibrary;
 use process::ProcessLibrary;

--- a/implants/lib/eldritch/src/lib.rs
+++ b/implants/lib/eldritch/src/lib.rs
@@ -30,8 +30,6 @@ pub fn get_eldritch() -> anyhow::Result<Globals> {
         const assets: AssetsLibrary = AssetsLibrary();
     }
 
-    // let extended_globals = Globals::extended_internal();
-    // let globals = GlobalsBuilder::new().with(eldritch).build();
     let globals = GlobalsBuilder::extended_by(
         &[
             LibraryExtension::StructType,

--- a/implants/lib/eldritch/src/pivot.rs
+++ b/implants/lib/eldritch/src/pivot.rs
@@ -29,6 +29,7 @@ use serde::{Serialize,Serializer};
 pub struct PivotLibrary();
 starlark_simple_value!(PivotLibrary);
 
+#[allow(non_upper_case_globals)]
 #[starlark_value(type = "pivot_library")]
 impl<'v> StarlarkValue<'v> for PivotLibrary {
 

--- a/implants/lib/eldritch/src/pivot.rs
+++ b/implants/lib/eldritch/src/pivot.rs
@@ -19,8 +19,8 @@ use russh_keys::{key, decode_secret_key};
 use starlark::values::dict::Dict;
 use starlark::environment::{Methods, MethodsBuilder, MethodsStatic};
 use starlark::values::none::NoneType;
-use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType, Heap};
-use starlark::{starlark_type, starlark_simple_value, starlark_module};
+use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType, Heap, starlark_value};
+use starlark::{starlark_simple_value, starlark_module};
 
 use serde::{Serialize,Serializer};
 use tokio::net::ToSocketAddrs;
@@ -30,8 +30,8 @@ use tokio::net::ToSocketAddrs;
 pub struct PivotLibrary();
 starlark_simple_value!(PivotLibrary);
 
+#[starlark_value(type = "pivot_library")]
 impl<'v> StarlarkValue<'v> for PivotLibrary {
-    starlark_type!("pivot_library");
 
     fn get_methods() -> Option<&'static Methods> {
         static RES: MethodsStatic = MethodsStatic::new();

--- a/implants/lib/eldritch/src/pivot.rs
+++ b/implants/lib/eldritch/src/pivot.rs
@@ -23,7 +23,6 @@ use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesSta
 use starlark::{starlark_simple_value, starlark_module};
 
 use serde::{Serialize,Serializer};
-use tokio::net::ToSocketAddrs;
 
 #[derive(Copy, Clone, Debug, PartialEq, Display, ProvidesStaticType, Allocative)]
 #[display(fmt = "PivotLibrary")]

--- a/implants/lib/eldritch/src/pivot/port_scan_impl.rs
+++ b/implants/lib/eldritch/src/pivot/port_scan_impl.rs
@@ -609,7 +609,7 @@ res
         match AstModule::parse(
                 "test.eldritch",
                 test_content.to_owned(),
-                &Dialect::Standard
+                &Dialect::Extended
             ) {
                 Ok(res) => ast = res,
                 Err(err) => return Err(err),

--- a/implants/lib/eldritch/src/pivot/port_scan_impl.rs
+++ b/implants/lib/eldritch/src/pivot/port_scan_impl.rs
@@ -362,7 +362,7 @@ pub fn port_scan(starlark_heap: &Heap, target_cidrs: Vec<String>, ports: Vec<i32
                 let tmp_value1 = starlark_heap.alloc_str(row.0.as_str());
                 tmp_res.insert_hashed(const_frozen_string!("ip").to_value().get_hashed().unwrap(), tmp_value1.to_value());
 
-                tmp_res.insert_hashed(const_frozen_string!("port").to_value().get_hashed().unwrap(), Value::new_int(row.1));
+                tmp_res.insert_hashed(const_frozen_string!("port").to_value().get_hashed().unwrap(), starlark_heap.alloc(row.1));
 
                 let tmp_value2 = starlark_heap.alloc_str(row.2.as_str());
                 tmp_res.insert_hashed(const_frozen_string!("protocol").to_value().get_hashed().unwrap(), tmp_value2.to_value());
@@ -623,7 +623,7 @@ res
             }
         }
 
-        let globals = GlobalsBuilder::extended().with(func_port_scan).build();
+        let globals = GlobalsBuilder::standard().with(func_port_scan).build();
         let module: Module = Module::new();
 
         let mut eval: Evaluator = Evaluator::new(&module);

--- a/implants/lib/eldritch/src/pivot/ssh_exec_impl.rs
+++ b/implants/lib/eldritch/src/pivot/ssh_exec_impl.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use starlark::{values::{dict::Dict, Heap, Value}, collections::SmallMap, const_frozen_string};
+use starlark::{values::{dict::Dict, Heap}, collections::SmallMap, const_frozen_string};
 
 use super::Session;
 

--- a/implants/lib/eldritch/src/pivot/ssh_exec_impl.rs
+++ b/implants/lib/eldritch/src/pivot/ssh_exec_impl.rs
@@ -47,7 +47,7 @@ pub fn ssh_exec(starlark_heap: &Heap, target: String, port: i32, command: String
     let stdout_value = starlark_heap.alloc_str(&cmd_res.stdout);
     dict_res.insert_hashed(const_frozen_string!("stdout").to_value().get_hashed().unwrap(), stdout_value.to_value());
 
-    let status_value = Value::new_int(cmd_res.status);
+    let status_value = starlark_heap.alloc(cmd_res.status);
     dict_res.insert_hashed(const_frozen_string!("status").to_value().get_hashed().unwrap(), status_value);
 
     Ok(dict_res)
@@ -185,7 +185,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pivot_ssh_exec() -> anyhow::Result<()> {
-        let ssh_port = allocate_localhost_unused_ports().await? as u16;;
+        let ssh_port = allocate_localhost_unused_ports().await? as u16;
         let ssh_host = "127.0.0.1".to_string();
         let ssh_command = r#"echo "hello world""#.to_string();
         let test_server_task = task::spawn(

--- a/implants/lib/eldritch/src/process.rs
+++ b/implants/lib/eldritch/src/process.rs
@@ -18,6 +18,7 @@ use serde::{Serialize,Serializer};
 pub struct ProcessLibrary();
 starlark_simple_value!(ProcessLibrary);
 
+#[allow(non_upper_case_globals)]
 #[starlark_value(type = "process_library")]
 impl<'v> StarlarkValue<'v> for ProcessLibrary {
 

--- a/implants/lib/eldritch/src/process.rs
+++ b/implants/lib/eldritch/src/process.rs
@@ -8,8 +8,8 @@ use derive_more::Display;
 use starlark::environment::{Methods, MethodsBuilder, MethodsStatic};
 use starlark::values::dict::Dict;
 use starlark::values::none::NoneType;
-use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType, Heap};
-use starlark::{starlark_type, starlark_simple_value, starlark_module};
+use starlark::values::{StarlarkValue, Value, UnpackValue, ValueLike, ProvidesStaticType, Heap, starlark_value};
+use starlark::{starlark_simple_value, starlark_module};
 
 use serde::{Serialize,Serializer};
 
@@ -18,8 +18,8 @@ use serde::{Serialize,Serializer};
 pub struct ProcessLibrary();
 starlark_simple_value!(ProcessLibrary);
 
+#[starlark_value(type = "process_library")]
 impl<'v> StarlarkValue<'v> for ProcessLibrary {
-    starlark_type!("process_library");
 
     fn get_methods() -> Option<&'static Methods> {
         static RES: MethodsStatic = MethodsStatic::new();

--- a/implants/lib/eldritch/src/sys.rs
+++ b/implants/lib/eldritch/src/sys.rs
@@ -29,6 +29,7 @@ struct CommandOutput {
 pub struct SysLibrary();
 starlark_simple_value!(SysLibrary);
 
+#[allow(non_upper_case_globals)]
 #[starlark_value(type = "sys_library")]
 impl<'v> StarlarkValue<'v> for SysLibrary {
 

--- a/implants/lib/eldritch/src/sys.rs
+++ b/implants/lib/eldritch/src/sys.rs
@@ -12,8 +12,9 @@ use derive_more::Display;
 
 use starlark::environment::{Methods, MethodsBuilder, MethodsStatic};
 use starlark::values::none::NoneType;
+use starlark::values::starlark_value;
 use starlark::values::{StarlarkValue, Value, Heap, dict::Dict, UnpackValue, ValueLike, ProvidesStaticType};
-use starlark::{starlark_type, starlark_simple_value, starlark_module};
+use starlark::{starlark_simple_value, starlark_module};
 
 use serde::{Serialize,Serializer};
 
@@ -28,8 +29,8 @@ struct CommandOutput {
 pub struct SysLibrary();
 starlark_simple_value!(SysLibrary);
 
+#[starlark_value(type = "sys_library")]
 impl<'v> StarlarkValue<'v> for SysLibrary {
-    starlark_type!("sys_library");
 
     fn get_methods() -> Option<&'static Methods> {
         static RES: MethodsStatic = MethodsStatic::new();

--- a/implants/lib/eldritch/src/sys/exec_impl.rs
+++ b/implants/lib/eldritch/src/sys/exec_impl.rs
@@ -22,7 +22,7 @@ pub fn exec(starlark_heap: &Heap, path: String, args: Vec<String>, disown: Optio
     let stderr_value = starlark_heap.alloc_str(cmd_res.stderr.as_str());
     dict_res.insert_hashed(const_frozen_string!("stderr").to_value().get_hashed().unwrap(), stderr_value.to_value());
 
-    let status_value = Value::new_int(cmd_res.status);
+    let status_value = starlark_heap.alloc(cmd_res.status);
     dict_res.insert_hashed(const_frozen_string!("status").to_value().get_hashed().unwrap(), status_value);
 
     Ok(dict_res)

--- a/implants/lib/eldritch/src/sys/exec_impl.rs
+++ b/implants/lib/eldritch/src/sys/exec_impl.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use starlark::{values::{Heap, dict::Dict, Value}, collections::SmallMap, const_frozen_string};
+use starlark::{values::{Heap, dict::Dict}, collections::SmallMap, const_frozen_string};
 use std::process::Command;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use nix::{sys::wait::waitpid, unistd::{fork, ForkResult}};

--- a/implants/lib/eldritch/src/sys/shell_impl.rs
+++ b/implants/lib/eldritch/src/sys/shell_impl.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use starlark::collections::SmallMap;
 use starlark::const_frozen_string;
-use starlark::values::{Heap, Value};
+use starlark::values::Heap;
 use starlark::values::dict::Dict;
-use std::process::{Command};
+use std::process::Command;
 use std::str;
 
 use super::CommandOutput;

--- a/implants/lib/eldritch/src/sys/shell_impl.rs
+++ b/implants/lib/eldritch/src/sys/shell_impl.rs
@@ -20,7 +20,7 @@ pub fn shell(starlark_heap: &Heap, cmd: String) -> Result<Dict> {
     let stderr_value = starlark_heap.alloc_str(cmd_res.stderr.as_str());
     dict_res.insert_hashed(const_frozen_string!("stderr").to_value().get_hashed().unwrap(), stderr_value.to_value());
 
-    let status_value = Value::new_int(cmd_res.status);
+    let status_value = starlark_heap.alloc(cmd_res.status);
     dict_res.insert_hashed(const_frozen_string!("status").to_value().get_hashed().unwrap(), status_value);
 
     Ok(dict_res)
@@ -117,7 +117,7 @@ func_shell("whoami")
             }
         }
 
-        let globals = GlobalsBuilder::extended().with(func_shell).build();
+        let globals = GlobalsBuilder::standard().with(func_shell).build();
         let module: Module = Module::new();
 
         let mut eval: Evaluator = Evaluator::new(&module);


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Updates to the latest commit of starlark rust `1109aaf9b700d7cdd7ba48986aa650221b70a22f`
This puts us in `v0.9.0`
- Adds support for web assembly compilation.
- starlark ints are no longer built with `Vaule::new_int(2)` it's now `starlark_heap.alloc(2)`.
- Modules and other value types are defined with `#[starlark_value(type = "assets_library")]` instead of `starlark_type!("assets_library");`
- GlobalsBuilder::extended() is no longer exposed and so each library extension now needs to be manually provided.
- Should make it easier to implement custom types.

#### Which issue(s) this PR fixes:
