### PR TITLE
Differentiate IP Crate for Windows and Nix

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -26,10 +26,8 @@ httptest = "0.15.4"
 ipnetwork = "0.20.0"
 itertools = "0.10"
 lsp-types = "0.93.0"
-network-interface = "1.0.1"
 nix = "0.26.1"
 openssl = "0.10"
-pnet = "0.34.0"
 predicates = "2.1"
 rand = "0.8.5"
 regex = "1.5.5"
@@ -56,6 +54,12 @@ tokio-test = "*"
 uuid = "1.3.0"
 whoami = "1.3.0"
 windows-sys = "0.45.0"
+
+#[target.'cfg(windows)'.dependencies]
+network-interface = "1.0.1"
+
+#[target.'cfg(not(windows))'.dependencies]
+pnet = "0.34.0"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -26,8 +26,10 @@ httptest = "0.15.4"
 ipnetwork = "0.20.0"
 itertools = "0.10"
 lsp-types = "0.93.0"
+network-interface = "1.0.1"
 nix = "0.26.1"
 openssl = "0.10"
+pnet = "0.34.0"
 predicates = "2.1"
 rand = "0.8.5"
 regex = "1.5.5"
@@ -54,12 +56,6 @@ tokio-test = "*"
 uuid = "1.3.0"
 whoami = "1.3.0"
 windows-sys = "0.45.0"
-
-#[target.'cfg(windows)'.dependencies]
-network-interface = "1.0.1"
-
-#[target.'cfg(not(windows))'.dependencies]
-pnet = "0.34.0"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/implants/lib/eldritch/Cargo.toml
+++ b/implants/lib/eldritch/Cargo.toml
@@ -15,9 +15,7 @@ eval = { workspace = true }
 flate2 = { workspace = true }
 gazebo = { workspace = true }
 ipnetwork = { workspace = true }
-network-interface = { workspace = true }
 nix = { workspace = true }
-pnet = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true , features = ["blocking", "stream"] }
 russh = { workspace = true }
@@ -42,6 +40,12 @@ windows-sys = { workspace = true, features = [
     "Win32_Security",
 ]}
 whoami = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+network-interface = { workspace = true }
+
+[target.'cfg(not(windows))'.dependencies]
+pnet = { workspace = true }
 
 [dev-dependencies]
 httptest = { workspace = true }

--- a/implants/lib/eldritch/src/sys/get_ip_impl.rs
+++ b/implants/lib/eldritch/src/sys/get_ip_impl.rs
@@ -1,16 +1,21 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+#[cfg(target_os = "windows")]
 use network_interface::{NetworkInterfaceConfig, NetworkInterface};
+#[cfg(not(target_os = "windows"))]
+use pnet::datalink::{interfaces, NetworkInterface};
 use starlark::{values::{dict::Dict, Heap, Value}, collections::SmallMap, const_frozen_string};
 
 const UNKNOWN: &str = "UNKNOWN";
 
 #[derive(Debug)]
+#[cfg(target_os = "windows")]
 struct NetInterface {
     name: String,
     ips: Vec<std::net::IpAddr>, //IPv6 and IPv4 Addresses on the itnerface
     mac: String,
 }
 
+#[cfg(target_os = "windows")]
 fn handle_get_ip() -> Result<Vec<NetInterface>> {
     let mut res = Vec::new();
     for network_interface in NetworkInterface::show()? {
@@ -34,6 +39,12 @@ fn handle_get_ip() -> Result<Vec<NetInterface>> {
     Ok(res)
 }
 
+#[cfg(not(target_os = "windows"))]
+fn handle_get_ip() -> Result<Vec<NetworkInterface>> {
+    Ok(interfaces())
+}
+
+#[cfg(target_os = "windows")]
 fn create_dict_from_interface(starlark_heap: &Heap, interface: NetInterface) -> Result<Dict>{
     let res: SmallMap<Value, Value> = SmallMap::new();
     let mut tmp_res = Dict::new(res);
@@ -55,6 +66,27 @@ fn create_dict_from_interface(starlark_heap: &Heap, interface: NetInterface) -> 
     Ok(tmp_res)
 }
 
+#[cfg(not(target_os = "windows"))]
+fn create_dict_from_interface(starlark_heap: &Heap, interface: NetworkInterface) -> Result<Dict>{
+    let res: SmallMap<Value, Value> = SmallMap::new();
+    let mut tmp_res = Dict::new(res);
+
+    let tmp_value1 = starlark_heap.alloc_str(&interface.name);
+    tmp_res.insert_hashed(const_frozen_string!("name").to_value().get_hashed().unwrap(), tmp_value1.to_value());
+
+    let mut tmp_value2_arr = Vec::<Value>::new();
+    for ip in interface.ips {
+        tmp_value2_arr.push(starlark_heap.alloc_str(&ip.to_string()).to_value());
+    }
+    let tmp_value2 = starlark_heap.alloc(tmp_value2_arr);
+    tmp_res.insert_hashed(const_frozen_string!("ips").to_value().get_hashed().unwrap(), tmp_value2);
+
+    let tmp_value3 = starlark_heap.alloc_str(&interface.mac.map(|mac| mac.to_string()).unwrap_or(UNKNOWN.to_string()));
+    tmp_res.insert_hashed(const_frozen_string!("mac").to_value().get_hashed().unwrap(), tmp_value3.to_value());
+
+
+    Ok(tmp_res)
+}
 
 pub fn get_ip(starlark_heap: &Heap) -> Result<Vec<Dict>> {
     let mut final_res: Vec<Dict> = Vec::new();


### PR DESCRIPTION
#### What type of PR is this?
Add one of the following kinds:
/kind cleanup

/kind api-change
/kind eldritch-function

#### What this PR does / why we need it:
Limits use of the `network_interface` crate to windows only. Allows realm to be FreeBSD compatible.

#### Which issue(s) this PR fixes:
N/A
