### PR TITLE
Change Bind Address to an Env Var

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.3'
+
+services:
+  db:
+    image: mariadb
+    restart: always
+    environment:
+      - MARIADB_RANDOM_ROOT_PASSWORD=yes
+      - MARIADB_USER=tavern
+      - MARIADB_PASSWORD=plodder09*arouse
+      - MARIADB_DATABASE=tavern
+    networks:
+      - internal
+  tavern:
+    image: tavern
+    restart: always
+    depends_on:
+      - db
+    build:
+      context: ..
+      dockerfile: ./docker/tavern.Dockerfile
+    environment:
+      - TAVERN_BIND=0.0.0.0:8080
+      - OAUTH_CLIENT_ID=
+      - OAUTH_CLIENT_SECRET=
+      - OAUTH_DOMAIN=
+      - MYSQL_ADDR=db
+      - MYSQL_USER=tavern
+      - MYSQL_PASSWD=plodder09*arouse
+    ports:
+      - 8080:8080
+    networks:
+      - internal
+networks:
+  internal:
+

--- a/docker/tavern.Dockerfile
+++ b/docker/tavern.Dockerfile
@@ -21,3 +21,4 @@ CMD ["/app/tavern"]
 EXPOSE 80 443 8080
 RUN apt-get update -y && apt-get install -y ca-certificates
 COPY --from=prod-build /app/build/tavern /app/tavern
+

--- a/tavern/app.go
+++ b/tavern/app.go
@@ -141,7 +141,7 @@ func NewServer(ctx context.Context, options ...func(*Config)) (*Server, error) {
 	// Initialize HTTP Server
 	if cfg.srv == nil {
 		cfg.srv = &http.Server{
-			Addr:    "0.0.0.0:80",
+			Addr:    GetBindAddress(),
 			Handler: endpoint,
 		}
 	} else {

--- a/tavern/config.go
+++ b/tavern/config.go
@@ -16,6 +16,9 @@ import (
 )
 
 var (
+	// Port to run on
+	EnvBind = EnvString{"TAVERN_BIND", "127.0.0.1:8080"}
+
 	// EnvEnableTestData if set will populate the database with test data.
 	EnvEnableTestData = EnvString{"ENABLE_TEST_DATA", ""}
 
@@ -99,6 +102,10 @@ func (cfg *Config) Connect(options ...ent.Option) (*ent.Client, error) {
 	return ent.NewClient(append(options, ent.Driver(drv))...), nil
 }
 
+func GetBindAddress() string {
+	return EnvBind.String()
+}
+
 // IsTestDataEnabled returns true if a value for the "ENABLE_TEST_DATA" environment variable is set.
 func (cfg *Config) IsTestDataEnabled() bool {
 	return EnvEnableTestData.String() != ""
@@ -106,9 +113,9 @@ func (cfg *Config) IsTestDataEnabled() bool {
 
 // ConfigureHTTPServer enables the configuration of the Tavern HTTP server. The endpoint field will be
 // overwritten with Tavern's HTTP handler when Tavern is run.
-func ConfigureHTTPServer(address string, options ...func(*http.Server)) func(*Config) {
+func ConfigureHTTPServer(options ...func(*http.Server)) func(*Config) {
 	srv := &http.Server{
-		Addr: address,
+		Addr: EnvBind.String(),
 	}
 	for _, opt := range options {
 		opt(srv)

--- a/tavern/main.go
+++ b/tavern/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	ctx := context.Background()
 	app := newApp(ctx,
-		ConfigureHTTPServer("0.0.0.0:80"),
+		ConfigureHTTPServer(),
 		ConfigureMySQLFromEnv(),
 		ConfigureOAuthFromEnv("/oauth/authorize"),
 	)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
I wanted to host tavern using a different port, but don't want people who also want to do this to have to change the code and re-compile. This makes the bind address an env var you can add (to the fancy new docker-compose.yml)


#### Which issue(s) this PR fixes:

