### PR TITLE
Allow unactivated users to query Me() graphql

### DIFF
--- a/implants/lib/tavern/graphql/schema.graphql
+++ b/implants/lib/tavern/graphql/schema.graphql
@@ -1077,6 +1077,6 @@ extend type Query {
   tags(where: TagWhereInput): [Tag!]! @requireRole(role: USER)
   tomes(where: TomeWhereInput): [Tome!]! @requireRole(role: USER)
   users(where: UserWhereInput): [User!]! @requireRole(role: USER)
-  me: User! @requireRole(role: USER)
+  me: User!
 }
 scalar Time

--- a/tavern/internal/graphql/generated/ent.generated.go
+++ b/tavern/internal/graphql/generated/ent.generated.go
@@ -2159,32 +2159,8 @@ func (ec *executionContext) _Query_me(ctx context.Context, field graphql.Collect
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().Me(rctx)
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋkcarrettoᚋrealmᚋtavernᚋinternalᚋgraphqlᚋmodelsᚐRole(ctx, "USER")
-			if err != nil {
-				return nil, err
-			}
-			if ec.directives.RequireRole == nil {
-				return nil, errors.New("directive requireRole is not implemented")
-			}
-			return ec.directives.RequireRole(ctx, nil, directive0, role)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*ent.User); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/kcarretto/realm/tavern/internal/ent.User`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Me(rctx)
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/tavern/internal/graphql/generated/root_.generated.go
+++ b/tavern/internal/graphql/generated/root_.generated.go
@@ -1965,7 +1965,7 @@ input UserWhereInput {
   tags(where: TagWhereInput): [Tag!]! @requireRole(role: USER)
   tomes(where: TomeWhereInput): [Tome!]! @requireRole(role: USER)
   users(where: UserWhereInput): [User!]! @requireRole(role: USER)
-  me: User! @requireRole(role: USER)
+  me: User!
 }
 `, BuiltIn: false},
 	{Name: "../schema/mutation.graphql", Input: `type Mutation {

--- a/tavern/internal/graphql/schema.graphql
+++ b/tavern/internal/graphql/schema.graphql
@@ -1077,6 +1077,6 @@ extend type Query {
   tags(where: TagWhereInput): [Tag!]! @requireRole(role: USER)
   tomes(where: TomeWhereInput): [Tome!]! @requireRole(role: USER)
   users(where: UserWhereInput): [User!]! @requireRole(role: USER)
-  me: User! @requireRole(role: USER)
+  me: User!
 }
 scalar Time

--- a/tavern/internal/graphql/schema/query.graphql
+++ b/tavern/internal/graphql/schema/query.graphql
@@ -6,5 +6,5 @@ extend type Query {
   tags(where: TagWhereInput): [Tag!]! @requireRole(role: USER)
   tomes(where: TomeWhereInput): [Tome!]! @requireRole(role: USER)
   users(where: UserWhereInput): [User!]! @requireRole(role: USER)
-  me: User! @requireRole(role: USER)
+  me: User!
 }

--- a/tavern/internal/graphql/testdata/queries/users/MeUnauthenticated.yml
+++ b/tavern/internal/graphql/testdata/queries/users/MeUnauthenticated.yml
@@ -1,0 +1,12 @@
+state: |
+  INSERT INTO `users` (id,oauth_id,photo_url,name,session_token,is_activated,is_admin)
+    VALUES (5,"test_oauth_id","https://photos.com","test","secretToken",false,false);
+  INSERT INTO `users` (id,oauth_id,photo_url,name,session_token,is_activated,is_admin)
+    VALUES (6,"test_oauth_id2","https://photos.com","admin","otherToken",true,true);
+query: |
+  query UnauthenticatedMe {
+    me {
+      id
+    }
+  }
+expected_error: no authenticated user present in request context

--- a/tavern/internal/graphql/testdata/queries/users/MeWithUnactivatedUser.yml
+++ b/tavern/internal/graphql/testdata/queries/users/MeWithUnactivatedUser.yml
@@ -1,0 +1,18 @@
+state: |
+  INSERT INTO `users` (id,oauth_id,photo_url,name,session_token,is_activated,is_admin)
+    VALUES (5,"test_oauth_id","https://photos.com","test","secretToken",false,false);
+  INSERT INTO `users` (id,oauth_id,photo_url,name,session_token,is_activated,is_admin)
+    VALUES (6,"test_oauth_id2","https://photos.com","admin","otherToken",true,true);
+requestor:
+  session_token: secretToken
+query: |
+  query MeWithUnactivatedUser {
+    me {
+      id
+      isActivated
+    }
+  }
+expected:
+  me:
+    id: "5"
+    isActivated: false

--- a/tavern/internal/www/schema.graphql
+++ b/tavern/internal/www/schema.graphql
@@ -1077,6 +1077,6 @@ extend type Query {
   tags(where: TagWhereInput): [Tag!]! @requireRole(role: USER)
   tomes(where: TomeWhereInput): [Tome!]! @requireRole(role: USER)
   users(where: UserWhereInput): [User!]! @requireRole(role: USER)
-  me: User! @requireRole(role: USER)
+  me: User!
 }
 scalar Time


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind bug 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

Allow unactivated users to perform the GraphQL `Me` query. This will enable the UI to query information about users who have not yet been approved by an administrator.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #339 
