### PR TITLE
Add Windows Path for system-id

### DIFF
--- a/implants/imix/src/main.rs
+++ b/implants/imix/src/main.rs
@@ -235,8 +235,14 @@ async fn main_loop(config_path: String, loop_count_max: Option<i32>) -> Result<(
             None
         },
     };
+    
+    let host_id_file = if cfg!(target_os="windows") {
+        "C:\\ProgramData\\system-id"
+    } else {
+        "/etc/system-id"
+    }.to_string();
 
-    let host_id = match get_host_id("/etc/system-id".to_string()) {
+    let host_id = match get_host_id(host_id_file) {
         Ok(tmp_host_id) => tmp_host_id,
         Err(error) => {
             if debug {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Every time a windows imix instance starts, it makes a new UUID that causes more hosts in the DB. There was no Windows file path specified.

#### Which issue(s) this PR fixes:
