### PR TITLE
[bugfix] fix n+1 query problem, manually specify CollectFields

### DIFF
--- a/tavern/internal/graphql/query.resolvers.go
+++ b/tavern/internal/graphql/query.resolvers.go
@@ -14,86 +14,114 @@ import (
 
 // Files is the resolver for the files field.
 func (r *queryResolver) Files(ctx context.Context, where *ent.FileWhereInput) ([]*ent.File, error) {
+	query, err := r.client.File.Query().CollectFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect fields: %w", err)
+	}
 	if where != nil {
-		query, err := where.Filter(r.client.File.Query())
+		query, err := where.Filter(query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply filter: %w", err)
 		}
 		return query.All(ctx)
 	}
-	return r.client.File.Query().All(ctx)
+	return query.All(ctx)
 }
 
 // Quests is the resolver for the quests field.
 func (r *queryResolver) Quests(ctx context.Context, where *ent.QuestWhereInput) ([]*ent.Quest, error) {
+	query, err := r.client.Quest.Query().CollectFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect fields: %w", err)
+	}
 	if where != nil {
-		query, err := where.Filter(r.client.Quest.Query())
+		query, err := where.Filter(query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply filter: %w", err)
 		}
 		return query.All(ctx)
 	}
-	return r.client.Quest.Query().All(ctx)
+	return query.All(ctx)
 }
 
 // Beacons is the resolver for the beacons field.
 func (r *queryResolver) Beacons(ctx context.Context, where *ent.BeaconWhereInput) ([]*ent.Beacon, error) {
+	query, err := r.client.Beacon.Query().CollectFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect fields: %w", err)
+	}
 	if where != nil {
-		query, err := where.Filter(r.client.Beacon.Query())
+		query, err := where.Filter(query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply filter: %w", err)
 		}
 		return query.All(ctx)
 	}
-	return r.client.Beacon.Query().All(ctx)
+	return query.All(ctx)
 }
 
 // Hosts is the resolver for the hosts field.
 func (r *queryResolver) Hosts(ctx context.Context, where *ent.HostWhereInput) ([]*ent.Host, error) {
+	query, err := r.client.Host.Query().CollectFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect fields: %w", err)
+	}
 	if where != nil {
-		query, err := where.Filter(r.client.Host.Query())
+		query, err := where.Filter(query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply filter: %w", err)
 		}
 		return query.All(ctx)
 	}
-	return r.client.Host.Query().All(ctx)
+	return query.All(ctx)
 }
 
 // Tags is the resolver for the tags field.
 func (r *queryResolver) Tags(ctx context.Context, where *ent.TagWhereInput) ([]*ent.Tag, error) {
+	query, err := r.client.Tag.Query().CollectFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect fields: %w", err)
+	}
 	if where != nil {
-		query, err := where.Filter(r.client.Tag.Query())
+		query, err := where.Filter(query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply filter: %w", err)
 		}
 		return query.All(ctx)
 	}
-	return r.client.Tag.Query().All(ctx)
+	return query.All(ctx)
 }
 
 // Tomes is the resolver for the tomes field.
 func (r *queryResolver) Tomes(ctx context.Context, where *ent.TomeWhereInput) ([]*ent.Tome, error) {
+	query, err := r.client.Tome.Query().CollectFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect fields: %w", err)
+	}
 	if where != nil {
-		query, err := where.Filter(r.client.Tome.Query())
+		query, err := where.Filter(query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply filter: %w", err)
 		}
 		return query.All(ctx)
 	}
-	return r.client.Tome.Query().All(ctx)
+	return query.All(ctx)
 }
 
 // Users is the resolver for the users field.
 func (r *queryResolver) Users(ctx context.Context, where *ent.UserWhereInput) ([]*ent.User, error) {
+	query, err := r.client.User.Query().CollectFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect fields: %w", err)
+	}
 	if where != nil {
-		query, err := where.Filter(r.client.User.Query())
+		query, err := where.Filter(query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply filter: %w", err)
 		}
 		return query.All(ctx)
 	}
-	return r.client.User.Query().All(ctx)
+	return query.All(ctx)
 }
 
 // Me is the resolver for the me field.

--- a/tavern/test_data.go
+++ b/tavern/test_data.go
@@ -182,6 +182,10 @@ func createTestData(ctx context.Context, client *ent.Client) {
 		SetOutput(loremIpsum).
 		SetQuest(printQuest).
 		SaveX(ctx)
+
+	for i := 0; i < 50; i++ {
+		createQuest(ctx, client, testBeacons...)
+	}
 }
 
 func newRandomIdentifier() string {
@@ -339,3 +343,30 @@ None
 --------
 
 `
+
+func createQuest(ctx context.Context, client *ent.Client, beacons ...*ent.Beacon) {
+	// Mid-Execution
+	testTome := client.Tome.Create().
+		SetName(newRandomIdentifier()).
+		SetDescription("Print a message for fun!").
+		SetEldritch(`print(input_params['msg'])`).
+		SetParamDefs(`[{"name":"msg","label":"Message","type":"string","placeholder":"something to print"}]`).
+		SaveX(ctx)
+
+	q := client.Quest.Create().
+		SetName(newRandomIdentifier()).
+		SetParameters(`{"msg":"Hello World!"}`).
+		SetTome(testTome).
+		SaveX(ctx)
+
+	for _, b := range beacons {
+		client.Task.Create().
+			SetBeacon(b).
+			SetCreatedAt(timeAgo(5 * time.Minute)).
+			SetClaimedAt(timeAgo(1 * time.Minute)).
+			SetExecStartedAt(timeAgo(5 * time.Second)).
+			SetOutput("Hello").
+			SetQuest(q).
+			SaveX(ctx)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

Recently, we encountered performance issues with large cardinality data-sets (reproducible with 50 quests, 900 tasks, 900 beacons, 300 hosts). This was due to the [N+1 Query Problem](https://entgo.io/docs/tutorial-todo-gql-field-collection/#problem). We had thought that EntGo would solve this issue for us, but as it turns out, we had to manually call `CollectFields` on each of our root level queries in order to enable eager-loading.  We also updated the test data in order to create a large enough dataset to reproduce the issue.
