### PR TITLE
[feature] Added new Uint64 GraphQL scalar, added Interval field to Beacon

### DIFF
--- a/tavern/internal/c2/server.go
+++ b/tavern/internal/c2/server.go
@@ -72,6 +72,7 @@ func (srv *Server) ClaimTasks(ctx context.Context, req *c2pb.ClaimTasksRequest) 
 		SetAgentIdentifier(req.Beacon.Agent.Identifier).
 		SetHostID(hostID).
 		SetLastSeenAt(now).
+		SetInterval(req.Beacon.Interval).
 		OnConflict().
 		UpdateNewValues().
 		ID(ctx)

--- a/tavern/internal/c2/testdata/claimTasks/NoTasks.yml
+++ b/tavern/internal/c2/testdata/claimTasks/NoTasks.yml
@@ -10,4 +10,5 @@ requests:
           platform: 1
         agent:
           identifier: test-case
+        interval: 300
     expected: {}

--- a/tavern/internal/ent/beacon/beacon.go
+++ b/tavern/internal/ent/beacon/beacon.go
@@ -22,6 +22,8 @@ const (
 	FieldAgentIdentifier = "agent_identifier"
 	// FieldLastSeenAt holds the string denoting the last_seen_at field in the database.
 	FieldLastSeenAt = "last_seen_at"
+	// FieldInterval holds the string denoting the interval field in the database.
+	FieldInterval = "interval"
 	// EdgeHost holds the string denoting the host edge name in mutations.
 	EdgeHost = "host"
 	// EdgeTasks holds the string denoting the tasks edge name in mutations.
@@ -52,6 +54,7 @@ var Columns = []string{
 	FieldIdentifier,
 	FieldAgentIdentifier,
 	FieldLastSeenAt,
+	FieldInterval,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "beacons"
@@ -121,6 +124,11 @@ func ByAgentIdentifier(opts ...sql.OrderTermOption) OrderOption {
 // ByLastSeenAt orders the results by the last_seen_at field.
 func ByLastSeenAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLastSeenAt, opts...).ToFunc()
+}
+
+// ByInterval orders the results by the interval field.
+func ByInterval(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldInterval, opts...).ToFunc()
 }
 
 // ByHostField orders the results by host field.

--- a/tavern/internal/ent/beacon/where.go
+++ b/tavern/internal/ent/beacon/where.go
@@ -80,6 +80,11 @@ func LastSeenAt(v time.Time) predicate.Beacon {
 	return predicate.Beacon(sql.FieldEQ(FieldLastSeenAt, v))
 }
 
+// Interval applies equality check predicate on the "interval" field. It's identical to IntervalEQ.
+func Interval(v uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldEQ(FieldInterval, v))
+}
+
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.Beacon {
 	return predicate.Beacon(sql.FieldEQ(FieldName, v))
@@ -408,6 +413,56 @@ func LastSeenAtIsNil() predicate.Beacon {
 // LastSeenAtNotNil applies the NotNil predicate on the "last_seen_at" field.
 func LastSeenAtNotNil() predicate.Beacon {
 	return predicate.Beacon(sql.FieldNotNull(FieldLastSeenAt))
+}
+
+// IntervalEQ applies the EQ predicate on the "interval" field.
+func IntervalEQ(v uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldEQ(FieldInterval, v))
+}
+
+// IntervalNEQ applies the NEQ predicate on the "interval" field.
+func IntervalNEQ(v uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldNEQ(FieldInterval, v))
+}
+
+// IntervalIn applies the In predicate on the "interval" field.
+func IntervalIn(vs ...uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldIn(FieldInterval, vs...))
+}
+
+// IntervalNotIn applies the NotIn predicate on the "interval" field.
+func IntervalNotIn(vs ...uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldNotIn(FieldInterval, vs...))
+}
+
+// IntervalGT applies the GT predicate on the "interval" field.
+func IntervalGT(v uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldGT(FieldInterval, v))
+}
+
+// IntervalGTE applies the GTE predicate on the "interval" field.
+func IntervalGTE(v uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldGTE(FieldInterval, v))
+}
+
+// IntervalLT applies the LT predicate on the "interval" field.
+func IntervalLT(v uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldLT(FieldInterval, v))
+}
+
+// IntervalLTE applies the LTE predicate on the "interval" field.
+func IntervalLTE(v uint64) predicate.Beacon {
+	return predicate.Beacon(sql.FieldLTE(FieldInterval, v))
+}
+
+// IntervalIsNil applies the IsNil predicate on the "interval" field.
+func IntervalIsNil() predicate.Beacon {
+	return predicate.Beacon(sql.FieldIsNull(FieldInterval))
+}
+
+// IntervalNotNil applies the NotNil predicate on the "interval" field.
+func IntervalNotNil() predicate.Beacon {
+	return predicate.Beacon(sql.FieldNotNull(FieldInterval))
 }
 
 // HasHost applies the HasEdge predicate on the "host" edge.

--- a/tavern/internal/ent/beacon_create.go
+++ b/tavern/internal/ent/beacon_create.go
@@ -94,6 +94,20 @@ func (bc *BeaconCreate) SetNillableLastSeenAt(t *time.Time) *BeaconCreate {
 	return bc
 }
 
+// SetInterval sets the "interval" field.
+func (bc *BeaconCreate) SetInterval(u uint64) *BeaconCreate {
+	bc.mutation.SetInterval(u)
+	return bc
+}
+
+// SetNillableInterval sets the "interval" field if the given value is not nil.
+func (bc *BeaconCreate) SetNillableInterval(u *uint64) *BeaconCreate {
+	if u != nil {
+		bc.SetInterval(*u)
+	}
+	return bc
+}
+
 // SetHostID sets the "host" edge to the Host entity by ID.
 func (bc *BeaconCreate) SetHostID(id int) *BeaconCreate {
 	bc.mutation.SetHostID(id)
@@ -242,6 +256,10 @@ func (bc *BeaconCreate) createSpec() (*Beacon, *sqlgraph.CreateSpec) {
 	if value, ok := bc.mutation.LastSeenAt(); ok {
 		_spec.SetField(beacon.FieldLastSeenAt, field.TypeTime, value)
 		_node.LastSeenAt = value
+	}
+	if value, ok := bc.mutation.Interval(); ok {
+		_spec.SetField(beacon.FieldInterval, field.TypeUint64, value)
+		_node.Interval = value
 	}
 	if nodes := bc.mutation.HostIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -394,6 +412,30 @@ func (u *BeaconUpsert) ClearLastSeenAt() *BeaconUpsert {
 	return u
 }
 
+// SetInterval sets the "interval" field.
+func (u *BeaconUpsert) SetInterval(v uint64) *BeaconUpsert {
+	u.Set(beacon.FieldInterval, v)
+	return u
+}
+
+// UpdateInterval sets the "interval" field to the value that was provided on create.
+func (u *BeaconUpsert) UpdateInterval() *BeaconUpsert {
+	u.SetExcluded(beacon.FieldInterval)
+	return u
+}
+
+// AddInterval adds v to the "interval" field.
+func (u *BeaconUpsert) AddInterval(v uint64) *BeaconUpsert {
+	u.Add(beacon.FieldInterval, v)
+	return u
+}
+
+// ClearInterval clears the value of the "interval" field.
+func (u *BeaconUpsert) ClearInterval() *BeaconUpsert {
+	u.SetNull(beacon.FieldInterval)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -513,6 +555,34 @@ func (u *BeaconUpsertOne) UpdateLastSeenAt() *BeaconUpsertOne {
 func (u *BeaconUpsertOne) ClearLastSeenAt() *BeaconUpsertOne {
 	return u.Update(func(s *BeaconUpsert) {
 		s.ClearLastSeenAt()
+	})
+}
+
+// SetInterval sets the "interval" field.
+func (u *BeaconUpsertOne) SetInterval(v uint64) *BeaconUpsertOne {
+	return u.Update(func(s *BeaconUpsert) {
+		s.SetInterval(v)
+	})
+}
+
+// AddInterval adds v to the "interval" field.
+func (u *BeaconUpsertOne) AddInterval(v uint64) *BeaconUpsertOne {
+	return u.Update(func(s *BeaconUpsert) {
+		s.AddInterval(v)
+	})
+}
+
+// UpdateInterval sets the "interval" field to the value that was provided on create.
+func (u *BeaconUpsertOne) UpdateInterval() *BeaconUpsertOne {
+	return u.Update(func(s *BeaconUpsert) {
+		s.UpdateInterval()
+	})
+}
+
+// ClearInterval clears the value of the "interval" field.
+func (u *BeaconUpsertOne) ClearInterval() *BeaconUpsertOne {
+	return u.Update(func(s *BeaconUpsert) {
+		s.ClearInterval()
 	})
 }
 
@@ -801,6 +871,34 @@ func (u *BeaconUpsertBulk) UpdateLastSeenAt() *BeaconUpsertBulk {
 func (u *BeaconUpsertBulk) ClearLastSeenAt() *BeaconUpsertBulk {
 	return u.Update(func(s *BeaconUpsert) {
 		s.ClearLastSeenAt()
+	})
+}
+
+// SetInterval sets the "interval" field.
+func (u *BeaconUpsertBulk) SetInterval(v uint64) *BeaconUpsertBulk {
+	return u.Update(func(s *BeaconUpsert) {
+		s.SetInterval(v)
+	})
+}
+
+// AddInterval adds v to the "interval" field.
+func (u *BeaconUpsertBulk) AddInterval(v uint64) *BeaconUpsertBulk {
+	return u.Update(func(s *BeaconUpsert) {
+		s.AddInterval(v)
+	})
+}
+
+// UpdateInterval sets the "interval" field to the value that was provided on create.
+func (u *BeaconUpsertBulk) UpdateInterval() *BeaconUpsertBulk {
+	return u.Update(func(s *BeaconUpsert) {
+		s.UpdateInterval()
+	})
+}
+
+// ClearInterval clears the value of the "interval" field.
+func (u *BeaconUpsertBulk) ClearInterval() *BeaconUpsertBulk {
+	return u.Update(func(s *BeaconUpsert) {
+		s.ClearInterval()
 	})
 }
 

--- a/tavern/internal/ent/beacon_update.go
+++ b/tavern/internal/ent/beacon_update.go
@@ -104,6 +104,33 @@ func (bu *BeaconUpdate) ClearLastSeenAt() *BeaconUpdate {
 	return bu
 }
 
+// SetInterval sets the "interval" field.
+func (bu *BeaconUpdate) SetInterval(u uint64) *BeaconUpdate {
+	bu.mutation.ResetInterval()
+	bu.mutation.SetInterval(u)
+	return bu
+}
+
+// SetNillableInterval sets the "interval" field if the given value is not nil.
+func (bu *BeaconUpdate) SetNillableInterval(u *uint64) *BeaconUpdate {
+	if u != nil {
+		bu.SetInterval(*u)
+	}
+	return bu
+}
+
+// AddInterval adds u to the "interval" field.
+func (bu *BeaconUpdate) AddInterval(u int64) *BeaconUpdate {
+	bu.mutation.AddInterval(u)
+	return bu
+}
+
+// ClearInterval clears the value of the "interval" field.
+func (bu *BeaconUpdate) ClearInterval() *BeaconUpdate {
+	bu.mutation.ClearInterval()
+	return bu
+}
+
 // SetHostID sets the "host" edge to the Host entity by ID.
 func (bu *BeaconUpdate) SetHostID(id int) *BeaconUpdate {
 	bu.mutation.SetHostID(id)
@@ -244,6 +271,15 @@ func (bu *BeaconUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if bu.mutation.LastSeenAtCleared() {
 		_spec.ClearField(beacon.FieldLastSeenAt, field.TypeTime)
+	}
+	if value, ok := bu.mutation.Interval(); ok {
+		_spec.SetField(beacon.FieldInterval, field.TypeUint64, value)
+	}
+	if value, ok := bu.mutation.AddedInterval(); ok {
+		_spec.AddField(beacon.FieldInterval, field.TypeUint64, value)
+	}
+	if bu.mutation.IntervalCleared() {
+		_spec.ClearField(beacon.FieldInterval, field.TypeUint64)
 	}
 	if bu.mutation.HostCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -410,6 +446,33 @@ func (buo *BeaconUpdateOne) SetNillableLastSeenAt(t *time.Time) *BeaconUpdateOne
 // ClearLastSeenAt clears the value of the "last_seen_at" field.
 func (buo *BeaconUpdateOne) ClearLastSeenAt() *BeaconUpdateOne {
 	buo.mutation.ClearLastSeenAt()
+	return buo
+}
+
+// SetInterval sets the "interval" field.
+func (buo *BeaconUpdateOne) SetInterval(u uint64) *BeaconUpdateOne {
+	buo.mutation.ResetInterval()
+	buo.mutation.SetInterval(u)
+	return buo
+}
+
+// SetNillableInterval sets the "interval" field if the given value is not nil.
+func (buo *BeaconUpdateOne) SetNillableInterval(u *uint64) *BeaconUpdateOne {
+	if u != nil {
+		buo.SetInterval(*u)
+	}
+	return buo
+}
+
+// AddInterval adds u to the "interval" field.
+func (buo *BeaconUpdateOne) AddInterval(u int64) *BeaconUpdateOne {
+	buo.mutation.AddInterval(u)
+	return buo
+}
+
+// ClearInterval clears the value of the "interval" field.
+func (buo *BeaconUpdateOne) ClearInterval() *BeaconUpdateOne {
+	buo.mutation.ClearInterval()
 	return buo
 }
 
@@ -583,6 +646,15 @@ func (buo *BeaconUpdateOne) sqlSave(ctx context.Context) (_node *Beacon, err err
 	}
 	if buo.mutation.LastSeenAtCleared() {
 		_spec.ClearField(beacon.FieldLastSeenAt, field.TypeTime)
+	}
+	if value, ok := buo.mutation.Interval(); ok {
+		_spec.SetField(beacon.FieldInterval, field.TypeUint64, value)
+	}
+	if value, ok := buo.mutation.AddedInterval(); ok {
+		_spec.AddField(beacon.FieldInterval, field.TypeUint64, value)
+	}
+	if buo.mutation.IntervalCleared() {
+		_spec.ClearField(beacon.FieldInterval, field.TypeUint64)
 	}
 	if buo.mutation.HostCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/tavern/internal/ent/gql_collection.go
+++ b/tavern/internal/ent/gql_collection.go
@@ -86,6 +86,11 @@ func (b *BeaconQuery) collectField(ctx context.Context, opCtx *graphql.Operation
 				selectedFields = append(selectedFields, beacon.FieldLastSeenAt)
 				fieldSeen[beacon.FieldLastSeenAt] = struct{}{}
 			}
+		case "interval":
+			if _, ok := fieldSeen[beacon.FieldInterval]; !ok {
+				selectedFields = append(selectedFields, beacon.FieldInterval)
+				fieldSeen[beacon.FieldInterval] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:

--- a/tavern/internal/ent/gql_pagination.go
+++ b/tavern/internal/ent/gql_pagination.go
@@ -325,6 +325,20 @@ var (
 			}
 		},
 	}
+	// BeaconOrderFieldInterval orders Beacon by interval.
+	BeaconOrderFieldInterval = &BeaconOrderField{
+		Value: func(b *Beacon) (ent.Value, error) {
+			return b.Interval, nil
+		},
+		column: beacon.FieldInterval,
+		toTerm: beacon.ByInterval,
+		toCursor: func(b *Beacon) Cursor {
+			return Cursor{
+				ID:    b.ID,
+				Value: b.Interval,
+			}
+		},
+	}
 )
 
 // String implement fmt.Stringer interface.
@@ -333,6 +347,8 @@ func (f BeaconOrderField) String() string {
 	switch f.column {
 	case BeaconOrderFieldLastSeenAt.column:
 		str = "LAST_SEEN_AT"
+	case BeaconOrderFieldInterval.column:
+		str = "INTERVAL"
 	}
 	return str
 }
@@ -351,6 +367,8 @@ func (f *BeaconOrderField) UnmarshalGQL(v interface{}) error {
 	switch str {
 	case "LAST_SEEN_AT":
 		*f = *BeaconOrderFieldLastSeenAt
+	case "INTERVAL":
+		*f = *BeaconOrderFieldInterval
 	default:
 		return fmt.Errorf("%s is not a valid BeaconOrderField", str)
 	}

--- a/tavern/internal/ent/gql_where_input.go
+++ b/tavern/internal/ent/gql_where_input.go
@@ -111,6 +111,18 @@ type BeaconWhereInput struct {
 	LastSeenAtIsNil  bool        `json:"lastSeenAtIsNil,omitempty"`
 	LastSeenAtNotNil bool        `json:"lastSeenAtNotNil,omitempty"`
 
+	// "interval" field predicates.
+	Interval       *uint64  `json:"interval,omitempty"`
+	IntervalNEQ    *uint64  `json:"intervalNEQ,omitempty"`
+	IntervalIn     []uint64 `json:"intervalIn,omitempty"`
+	IntervalNotIn  []uint64 `json:"intervalNotIn,omitempty"`
+	IntervalGT     *uint64  `json:"intervalGT,omitempty"`
+	IntervalGTE    *uint64  `json:"intervalGTE,omitempty"`
+	IntervalLT     *uint64  `json:"intervalLT,omitempty"`
+	IntervalLTE    *uint64  `json:"intervalLTE,omitempty"`
+	IntervalIsNil  bool     `json:"intervalIsNil,omitempty"`
+	IntervalNotNil bool     `json:"intervalNotNil,omitempty"`
+
 	// "host" edge predicates.
 	HasHost     *bool             `json:"hasHost,omitempty"`
 	HasHostWith []*HostWhereInput `json:"hasHostWith,omitempty"`
@@ -412,6 +424,36 @@ func (i *BeaconWhereInput) P() (predicate.Beacon, error) {
 	}
 	if i.LastSeenAtNotNil {
 		predicates = append(predicates, beacon.LastSeenAtNotNil())
+	}
+	if i.Interval != nil {
+		predicates = append(predicates, beacon.IntervalEQ(*i.Interval))
+	}
+	if i.IntervalNEQ != nil {
+		predicates = append(predicates, beacon.IntervalNEQ(*i.IntervalNEQ))
+	}
+	if len(i.IntervalIn) > 0 {
+		predicates = append(predicates, beacon.IntervalIn(i.IntervalIn...))
+	}
+	if len(i.IntervalNotIn) > 0 {
+		predicates = append(predicates, beacon.IntervalNotIn(i.IntervalNotIn...))
+	}
+	if i.IntervalGT != nil {
+		predicates = append(predicates, beacon.IntervalGT(*i.IntervalGT))
+	}
+	if i.IntervalGTE != nil {
+		predicates = append(predicates, beacon.IntervalGTE(*i.IntervalGTE))
+	}
+	if i.IntervalLT != nil {
+		predicates = append(predicates, beacon.IntervalLT(*i.IntervalLT))
+	}
+	if i.IntervalLTE != nil {
+		predicates = append(predicates, beacon.IntervalLTE(*i.IntervalLTE))
+	}
+	if i.IntervalIsNil {
+		predicates = append(predicates, beacon.IntervalIsNil())
+	}
+	if i.IntervalNotNil {
+		predicates = append(predicates, beacon.IntervalNotNil())
 	}
 
 	if i.HasHost != nil {

--- a/tavern/internal/ent/migrate/schema.go
+++ b/tavern/internal/ent/migrate/schema.go
@@ -16,6 +16,7 @@ var (
 		{Name: "identifier", Type: field.TypeString, Unique: true},
 		{Name: "agent_identifier", Type: field.TypeString, Nullable: true},
 		{Name: "last_seen_at", Type: field.TypeTime, Nullable: true},
+		{Name: "interval", Type: field.TypeUint64, Nullable: true},
 		{Name: "beacon_host", Type: field.TypeInt},
 	}
 	// BeaconsTable holds the schema information for the "beacons" table.
@@ -26,7 +27,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "beacons_hosts_host",
-				Columns:    []*schema.Column{BeaconsColumns[6]},
+				Columns:    []*schema.Column{BeaconsColumns[7]},
 				RefColumns: []*schema.Column{HostsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},

--- a/tavern/internal/ent/mutation.go
+++ b/tavern/internal/ent/mutation.go
@@ -52,6 +52,8 @@ type BeaconMutation struct {
 	identifier       *string
 	agent_identifier *string
 	last_seen_at     *time.Time
+	interval         *uint64
+	addinterval      *int64
 	clearedFields    map[string]struct{}
 	host             *int
 	clearedhost      bool
@@ -380,6 +382,76 @@ func (m *BeaconMutation) ResetLastSeenAt() {
 	delete(m.clearedFields, beacon.FieldLastSeenAt)
 }
 
+// SetInterval sets the "interval" field.
+func (m *BeaconMutation) SetInterval(u uint64) {
+	m.interval = &u
+	m.addinterval = nil
+}
+
+// Interval returns the value of the "interval" field in the mutation.
+func (m *BeaconMutation) Interval() (r uint64, exists bool) {
+	v := m.interval
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldInterval returns the old "interval" field's value of the Beacon entity.
+// If the Beacon object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BeaconMutation) OldInterval(ctx context.Context) (v uint64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldInterval is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldInterval requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldInterval: %w", err)
+	}
+	return oldValue.Interval, nil
+}
+
+// AddInterval adds u to the "interval" field.
+func (m *BeaconMutation) AddInterval(u int64) {
+	if m.addinterval != nil {
+		*m.addinterval += u
+	} else {
+		m.addinterval = &u
+	}
+}
+
+// AddedInterval returns the value that was added to the "interval" field in this mutation.
+func (m *BeaconMutation) AddedInterval() (r int64, exists bool) {
+	v := m.addinterval
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearInterval clears the value of the "interval" field.
+func (m *BeaconMutation) ClearInterval() {
+	m.interval = nil
+	m.addinterval = nil
+	m.clearedFields[beacon.FieldInterval] = struct{}{}
+}
+
+// IntervalCleared returns if the "interval" field was cleared in this mutation.
+func (m *BeaconMutation) IntervalCleared() bool {
+	_, ok := m.clearedFields[beacon.FieldInterval]
+	return ok
+}
+
+// ResetInterval resets all changes to the "interval" field.
+func (m *BeaconMutation) ResetInterval() {
+	m.interval = nil
+	m.addinterval = nil
+	delete(m.clearedFields, beacon.FieldInterval)
+}
+
 // SetHostID sets the "host" edge to the Host entity by id.
 func (m *BeaconMutation) SetHostID(id int) {
 	m.host = &id
@@ -507,7 +579,7 @@ func (m *BeaconMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BeaconMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 6)
 	if m.name != nil {
 		fields = append(fields, beacon.FieldName)
 	}
@@ -522,6 +594,9 @@ func (m *BeaconMutation) Fields() []string {
 	}
 	if m.last_seen_at != nil {
 		fields = append(fields, beacon.FieldLastSeenAt)
+	}
+	if m.interval != nil {
+		fields = append(fields, beacon.FieldInterval)
 	}
 	return fields
 }
@@ -541,6 +616,8 @@ func (m *BeaconMutation) Field(name string) (ent.Value, bool) {
 		return m.AgentIdentifier()
 	case beacon.FieldLastSeenAt:
 		return m.LastSeenAt()
+	case beacon.FieldInterval:
+		return m.Interval()
 	}
 	return nil, false
 }
@@ -560,6 +637,8 @@ func (m *BeaconMutation) OldField(ctx context.Context, name string) (ent.Value, 
 		return m.OldAgentIdentifier(ctx)
 	case beacon.FieldLastSeenAt:
 		return m.OldLastSeenAt(ctx)
+	case beacon.FieldInterval:
+		return m.OldInterval(ctx)
 	}
 	return nil, fmt.Errorf("unknown Beacon field %s", name)
 }
@@ -604,6 +683,13 @@ func (m *BeaconMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetLastSeenAt(v)
 		return nil
+	case beacon.FieldInterval:
+		v, ok := value.(uint64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetInterval(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Beacon field %s", name)
 }
@@ -611,13 +697,21 @@ func (m *BeaconMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *BeaconMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addinterval != nil {
+		fields = append(fields, beacon.FieldInterval)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *BeaconMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case beacon.FieldInterval:
+		return m.AddedInterval()
+	}
 	return nil, false
 }
 
@@ -626,6 +720,13 @@ func (m *BeaconMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *BeaconMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case beacon.FieldInterval:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddInterval(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Beacon numeric field %s", name)
 }
@@ -642,6 +743,9 @@ func (m *BeaconMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(beacon.FieldLastSeenAt) {
 		fields = append(fields, beacon.FieldLastSeenAt)
+	}
+	if m.FieldCleared(beacon.FieldInterval) {
+		fields = append(fields, beacon.FieldInterval)
 	}
 	return fields
 }
@@ -666,6 +770,9 @@ func (m *BeaconMutation) ClearField(name string) error {
 	case beacon.FieldLastSeenAt:
 		m.ClearLastSeenAt()
 		return nil
+	case beacon.FieldInterval:
+		m.ClearInterval()
+		return nil
 	}
 	return fmt.Errorf("unknown Beacon nullable field %s", name)
 }
@@ -688,6 +795,9 @@ func (m *BeaconMutation) ResetField(name string) error {
 		return nil
 	case beacon.FieldLastSeenAt:
 		m.ResetLastSeenAt()
+		return nil
+	case beacon.FieldInterval:
+		m.ResetInterval()
 		return nil
 	}
 	return fmt.Errorf("unknown Beacon field %s", name)

--- a/tavern/internal/ent/schema/beacon.go
+++ b/tavern/internal/ent/schema/beacon.go
@@ -58,6 +58,14 @@ func (Beacon) Fields() []ent.Field {
 				entgql.Skip(entgql.SkipMutationUpdateInput),
 			).
 			Comment("Timestamp of when a task was last claimed or updated for the beacon."),
+		field.Uint64("interval").
+			Optional().
+			Annotations(
+				entgql.Type("Uint64"),
+				entgql.OrderField("INTERVAL"),
+				entgql.Skip(entgql.SkipMutationUpdateInput),
+			).
+			Comment("Duration until next callback, in seconds."),
 	}
 }
 

--- a/tavern/internal/graphql/generated/ent.generated.go
+++ b/tavern/internal/graphql/generated/ent.generated.go
@@ -468,6 +468,47 @@ func (ec *executionContext) fieldContext_Beacon_lastSeenAt(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Beacon_interval(ctx context.Context, field graphql.CollectedField, obj *ent.Beacon) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Beacon_interval(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Interval, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalOUint642uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Beacon_interval(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Beacon",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Beacon_host(ctx context.Context, field graphql.CollectedField, obj *ent.Beacon) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Beacon_host(ctx, field)
 	if err != nil {
@@ -1211,6 +1252,8 @@ func (ec *executionContext) fieldContext_Host_beacons(ctx context.Context, field
 				return ec.fieldContext_Beacon_agentIdentifier(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Beacon_lastSeenAt(ctx, field)
+			case "interval":
+				return ec.fieldContext_Beacon_interval(ctx, field)
 			case "host":
 				return ec.fieldContext_Beacon_host(ctx, field)
 			case "tasks":
@@ -1867,6 +1910,8 @@ func (ec *executionContext) fieldContext_Query_beacons(ctx context.Context, fiel
 				return ec.fieldContext_Beacon_agentIdentifier(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Beacon_lastSeenAt(ctx, field)
+			case "interval":
+				return ec.fieldContext_Beacon_interval(ctx, field)
 			case "host":
 				return ec.fieldContext_Beacon_host(ctx, field)
 			case "tasks":
@@ -3541,6 +3586,8 @@ func (ec *executionContext) fieldContext_Task_beacon(ctx context.Context, field 
 				return ec.fieldContext_Beacon_agentIdentifier(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Beacon_lastSeenAt(ctx, field)
+			case "interval":
+				return ec.fieldContext_Beacon_interval(ctx, field)
 			case "host":
 				return ec.fieldContext_Beacon_host(ctx, field)
 			case "tasks":
@@ -4185,7 +4232,7 @@ func (ec *executionContext) unmarshalInputBeaconWhereInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "principal", "principalNEQ", "principalIn", "principalNotIn", "principalGT", "principalGTE", "principalLT", "principalLTE", "principalContains", "principalHasPrefix", "principalHasSuffix", "principalIsNil", "principalNotNil", "principalEqualFold", "principalContainsFold", "identifier", "identifierNEQ", "identifierIn", "identifierNotIn", "identifierGT", "identifierGTE", "identifierLT", "identifierLTE", "identifierContains", "identifierHasPrefix", "identifierHasSuffix", "identifierEqualFold", "identifierContainsFold", "agentIdentifier", "agentIdentifierNEQ", "agentIdentifierIn", "agentIdentifierNotIn", "agentIdentifierGT", "agentIdentifierGTE", "agentIdentifierLT", "agentIdentifierLTE", "agentIdentifierContains", "agentIdentifierHasPrefix", "agentIdentifierHasSuffix", "agentIdentifierIsNil", "agentIdentifierNotNil", "agentIdentifierEqualFold", "agentIdentifierContainsFold", "lastSeenAt", "lastSeenAtNEQ", "lastSeenAtIn", "lastSeenAtNotIn", "lastSeenAtGT", "lastSeenAtGTE", "lastSeenAtLT", "lastSeenAtLTE", "lastSeenAtIsNil", "lastSeenAtNotNil", "hasHost", "hasHostWith", "hasTasks", "hasTasksWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "principal", "principalNEQ", "principalIn", "principalNotIn", "principalGT", "principalGTE", "principalLT", "principalLTE", "principalContains", "principalHasPrefix", "principalHasSuffix", "principalIsNil", "principalNotNil", "principalEqualFold", "principalContainsFold", "identifier", "identifierNEQ", "identifierIn", "identifierNotIn", "identifierGT", "identifierGTE", "identifierLT", "identifierLTE", "identifierContains", "identifierHasPrefix", "identifierHasSuffix", "identifierEqualFold", "identifierContainsFold", "agentIdentifier", "agentIdentifierNEQ", "agentIdentifierIn", "agentIdentifierNotIn", "agentIdentifierGT", "agentIdentifierGTE", "agentIdentifierLT", "agentIdentifierLTE", "agentIdentifierContains", "agentIdentifierHasPrefix", "agentIdentifierHasSuffix", "agentIdentifierIsNil", "agentIdentifierNotNil", "agentIdentifierEqualFold", "agentIdentifierContainsFold", "lastSeenAt", "lastSeenAtNEQ", "lastSeenAtIn", "lastSeenAtNotIn", "lastSeenAtGT", "lastSeenAtGTE", "lastSeenAtLT", "lastSeenAtLTE", "lastSeenAtIsNil", "lastSeenAtNotNil", "interval", "intervalNEQ", "intervalIn", "intervalNotIn", "intervalGT", "intervalGTE", "intervalLT", "intervalLTE", "intervalIsNil", "intervalNotNil", "hasHost", "hasHostWith", "hasTasks", "hasTasksWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -4885,6 +4932,96 @@ func (ec *executionContext) unmarshalInputBeaconWhereInput(ctx context.Context, 
 				return it, err
 			}
 			it.LastSeenAtNotNil = data
+		case "interval":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("interval"))
+			data, err := ec.unmarshalOUint642ᚖuint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Interval = data
+		case "intervalNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalNEQ"))
+			data, err := ec.unmarshalOUint642ᚖuint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalNEQ = data
+		case "intervalIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalIn"))
+			data, err := ec.unmarshalOUint642ᚕuint64ᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalIn = data
+		case "intervalNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalNotIn"))
+			data, err := ec.unmarshalOUint642ᚕuint64ᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalNotIn = data
+		case "intervalGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalGT"))
+			data, err := ec.unmarshalOUint642ᚖuint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalGT = data
+		case "intervalGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalGTE"))
+			data, err := ec.unmarshalOUint642ᚖuint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalGTE = data
+		case "intervalLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalLT"))
+			data, err := ec.unmarshalOUint642ᚖuint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalLT = data
+		case "intervalLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalLTE"))
+			data, err := ec.unmarshalOUint642ᚖuint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalLTE = data
+		case "intervalIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalIsNil = data
+		case "intervalNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("intervalNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IntervalNotNil = data
 		case "hasHost":
 			var err error
 
@@ -9778,6 +9915,8 @@ func (ec *executionContext) _Beacon(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec._Beacon_agentIdentifier(ctx, field, obj)
 		case "lastSeenAt":
 			out.Values[i] = ec._Beacon_lastSeenAt(ctx, field, obj)
+		case "interval":
+			out.Values[i] = ec._Beacon_interval(ctx, field, obj)
 		case "host":
 			field := field
 

--- a/tavern/internal/graphql/generated/mutation.generated.go
+++ b/tavern/internal/graphql/generated/mutation.generated.go
@@ -392,6 +392,8 @@ func (ec *executionContext) fieldContext_Mutation_updateBeacon(ctx context.Conte
 				return ec.fieldContext_Beacon_agentIdentifier(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Beacon_lastSeenAt(ctx, field)
+			case "interval":
+				return ec.fieldContext_Beacon_interval(ctx, field)
 			case "host":
 				return ec.fieldContext_Beacon_host(ctx, field)
 			case "tasks":

--- a/tavern/internal/graphql/generated/root_.generated.go
+++ b/tavern/internal/graphql/generated/root_.generated.go
@@ -48,6 +48,7 @@ type ComplexityRoot struct {
 		Host            func(childComplexity int) int
 		ID              func(childComplexity int) int
 		Identifier      func(childComplexity int) int
+		Interval        func(childComplexity int) int
 		LastSeenAt      func(childComplexity int) int
 		Name            func(childComplexity int) int
 		Principal       func(childComplexity int) int
@@ -205,6 +206,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Beacon.Identifier(childComplexity), true
+
+	case "Beacon.interval":
+		if e.complexity.Beacon.Interval == nil {
+			break
+		}
+
+		return e.complexity.Beacon.Interval(childComplexity), true
 
 	case "Beacon.lastSeenAt":
 		if e.complexity.Beacon.LastSeenAt == nil {
@@ -996,6 +1004,8 @@ type Beacon implements Node {
   agentIdentifier: String
   """Timestamp of when a task was last claimed or updated for the beacon."""
   lastSeenAt: Time
+  """Duration until next callback, in seconds."""
+  interval: Uint64
   """Host this beacon is running on."""
   host: Host!
   """Tasks that have been assigned to the beacon."""
@@ -1011,6 +1021,7 @@ input BeaconOrder {
 """Properties by which Beacon connections can be ordered."""
 enum BeaconOrderField {
   LAST_SEEN_AT
+  INTERVAL
 }
 """
 BeaconWhereInput is used for filtering Beacon objects.
@@ -1100,6 +1111,17 @@ input BeaconWhereInput {
   lastSeenAtLTE: Time
   lastSeenAtIsNil: Boolean
   lastSeenAtNotNil: Boolean
+  """interval field predicates"""
+  interval: Uint64
+  intervalNEQ: Uint64
+  intervalIn: [Uint64!]
+  intervalNotIn: [Uint64!]
+  intervalGT: Uint64
+  intervalGTE: Uint64
+  intervalLT: Uint64
+  intervalLTE: Uint64
+  intervalIsNil: Boolean
+  intervalNotNil: Boolean
   """host edge predicates"""
   hasHost: Boolean
   hasHostWith: [HostWhereInput!]
@@ -1967,7 +1989,9 @@ input UserWhereInput {
   isAdminNEQ: Boolean
 }
 `, BuiltIn: false},
-	{Name: "../schema/scalars.graphql", Input: `scalar Time`, BuiltIn: false},
+	{Name: "../schema/scalars.graphql", Input: `scalar Time
+scalar Uint64
+`, BuiltIn: false},
 	{Name: "../schema/query.graphql", Input: `extend type Query {
   files(where: FileWhereInput): [File!]! @requireRole(role: USER)
   quests(where: QuestWhereInput): [Quest!]! @requireRole(role: USER)

--- a/tavern/internal/graphql/generated/scalars.generated.go
+++ b/tavern/internal/graphql/generated/scalars.generated.go
@@ -55,6 +55,21 @@ func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel as
 	return res
 }
 
+func (ec *executionContext) unmarshalNUint642uint64(ctx context.Context, v interface{}) (uint64, error) {
+	res, err := graphql.UnmarshalUint64(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUint642uint64(ctx context.Context, sel ast.SelectionSet, v uint64) graphql.Marshaler {
+	res := graphql.MarshalUint64(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalOTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
 	res, err := graphql.UnmarshalTime(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -116,6 +131,70 @@ func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel
 		return graphql.Null
 	}
 	res := graphql.MarshalTime(*v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOUint642uint64(ctx context.Context, v interface{}) (uint64, error) {
+	res, err := graphql.UnmarshalUint64(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOUint642uint64(ctx context.Context, sel ast.SelectionSet, v uint64) graphql.Marshaler {
+	res := graphql.MarshalUint64(v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOUint642ᚕuint64ᚄ(ctx context.Context, v interface{}) ([]uint64, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]uint64, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUint642uint64(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOUint642ᚕuint64ᚄ(ctx context.Context, sel ast.SelectionSet, v []uint64) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNUint642uint64(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalOUint642ᚖuint64(ctx context.Context, v interface{}) (*uint64, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalUint64(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOUint642ᚖuint64(ctx context.Context, sel ast.SelectionSet, v *uint64) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalUint64(*v)
 	return res
 }
 

--- a/tavern/internal/graphql/gqlgen.yml
+++ b/tavern/internal/graphql/gqlgen.yml
@@ -46,6 +46,11 @@ models:
       - github.com/kcarretto/realm/tavern/internal/ent.Noder
       # - entgo.io/contrib/entgql/internal/todo/ent.Noder
 
+  # Golang Types
+  Uint64:
+    model:
+      - github.com/99designs/gqlgen/graphql.Uint64
+
   # Enums
   Kind:
     model:

--- a/tavern/internal/graphql/schema.graphql
+++ b/tavern/internal/graphql/schema.graphql
@@ -17,6 +17,8 @@ type Beacon implements Node {
   agentIdentifier: String
   """Timestamp of when a task was last claimed or updated for the beacon."""
   lastSeenAt: Time
+  """Duration until next callback, in seconds."""
+  interval: Uint64
   """Host this beacon is running on."""
   host: Host!
   """Tasks that have been assigned to the beacon."""
@@ -32,6 +34,7 @@ input BeaconOrder {
 """Properties by which Beacon connections can be ordered."""
 enum BeaconOrderField {
   LAST_SEEN_AT
+  INTERVAL
 }
 """
 BeaconWhereInput is used for filtering Beacon objects.
@@ -121,6 +124,17 @@ input BeaconWhereInput {
   lastSeenAtLTE: Time
   lastSeenAtIsNil: Boolean
   lastSeenAtNotNil: Boolean
+  """interval field predicates"""
+  interval: Uint64
+  intervalNEQ: Uint64
+  intervalIn: [Uint64!]
+  intervalNotIn: [Uint64!]
+  intervalGT: Uint64
+  intervalGTE: Uint64
+  intervalLT: Uint64
+  intervalLTE: Uint64
+  intervalIsNil: Boolean
+  intervalNotNil: Boolean
   """host edge predicates"""
   hasHost: Boolean
   hasHostWith: [HostWhereInput!]
@@ -1079,3 +1093,4 @@ extend type Query {
   me: User!
 }
 scalar Time
+scalar Uint64

--- a/tavern/internal/graphql/schema/ent.graphql
+++ b/tavern/internal/graphql/schema/ent.graphql
@@ -12,6 +12,8 @@ type Beacon implements Node {
   agentIdentifier: String
   """Timestamp of when a task was last claimed or updated for the beacon."""
   lastSeenAt: Time
+  """Duration until next callback, in seconds."""
+  interval: Uint64
   """Host this beacon is running on."""
   host: Host!
   """Tasks that have been assigned to the beacon."""
@@ -27,6 +29,7 @@ input BeaconOrder {
 """Properties by which Beacon connections can be ordered."""
 enum BeaconOrderField {
   LAST_SEEN_AT
+  INTERVAL
 }
 """
 BeaconWhereInput is used for filtering Beacon objects.
@@ -116,6 +119,17 @@ input BeaconWhereInput {
   lastSeenAtLTE: Time
   lastSeenAtIsNil: Boolean
   lastSeenAtNotNil: Boolean
+  """interval field predicates"""
+  interval: Uint64
+  intervalNEQ: Uint64
+  intervalIn: [Uint64!]
+  intervalNotIn: [Uint64!]
+  intervalGT: Uint64
+  intervalGTE: Uint64
+  intervalLT: Uint64
+  intervalLTE: Uint64
+  intervalIsNil: Boolean
+  intervalNotNil: Boolean
   """host edge predicates"""
   hasHost: Boolean
   hasHostWith: [HostWhereInput!]

--- a/tavern/internal/graphql/schema/scalars.graphql
+++ b/tavern/internal/graphql/schema/scalars.graphql
@@ -1,1 +1,2 @@
 scalar Time
+scalar Uint64

--- a/tavern/internal/graphql/testdata/queries/beacons/Singular.yml
+++ b/tavern/internal/graphql/testdata/queries/beacons/Singular.yml
@@ -3,8 +3,8 @@ state: |
     VALUES (5,"test_oauth_id","https://photos.com","test","secretToken",true,true);
   INSERT INTO `hosts` (id, name, identifier)
     VALUES (1010,"db1","EXISTING-HOST");
-  INSERT INTO `beacons` (id, name, identifier, beacon_host)
-    VALUES (1337,"delightful-lich","ABCDEFG-123456",1010);
+  INSERT INTO `beacons` (id, name, identifier, beacon_host, interval)
+    VALUES (1337,"delightful-lich","ABCDEFG-123456",1010, 120);
 requestor:
   session_token: secretToken
 query: |
@@ -14,6 +14,7 @@ query: |
       host {
         id
       }
+      interval
     }
   }
 expected:
@@ -21,3 +22,4 @@ expected:
     - id: "1337"
       host:
         id: "1010"
+      interval: 120

--- a/tavern/internal/www/schema.graphql
+++ b/tavern/internal/www/schema.graphql
@@ -17,6 +17,8 @@ type Beacon implements Node {
   agentIdentifier: String
   """Timestamp of when a task was last claimed or updated for the beacon."""
   lastSeenAt: Time
+  """Duration until next callback, in seconds."""
+  interval: Uint64
   """Host this beacon is running on."""
   host: Host!
   """Tasks that have been assigned to the beacon."""
@@ -32,6 +34,7 @@ input BeaconOrder {
 """Properties by which Beacon connections can be ordered."""
 enum BeaconOrderField {
   LAST_SEEN_AT
+  INTERVAL
 }
 """
 BeaconWhereInput is used for filtering Beacon objects.
@@ -121,6 +124,17 @@ input BeaconWhereInput {
   lastSeenAtLTE: Time
   lastSeenAtIsNil: Boolean
   lastSeenAtNotNil: Boolean
+  """interval field predicates"""
+  interval: Uint64
+  intervalNEQ: Uint64
+  intervalIn: [Uint64!]
+  intervalNotIn: [Uint64!]
+  intervalGT: Uint64
+  intervalGTE: Uint64
+  intervalLT: Uint64
+  intervalLTE: Uint64
+  intervalIsNil: Boolean
+  intervalNotNil: Boolean
   """host edge predicates"""
   hasHost: Boolean
   hasHostWith: [HostWhereInput!]
@@ -1079,3 +1093,4 @@ extend type Query {
   me: User!
 }
 scalar Time
+scalar Uint64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

Adds a new `Interval` field to the `Beacon`, which will enable clients to estimate the next expected check-in time. It will also provide some more information about the frequency of callbacks, so that users can further distinguish between `Beacons`. This required adding a new Uint64 scalar to our GraphQL schema.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #394 
