### PR TITLE
time.now

### DIFF
--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -778,6 +778,10 @@ crypto.to_json({"foo": "bar"})
 
 ### time.sleep
 
+`time.now() -> int`
+
+The <b>time.now</b> method returns the time since UNIX EPOCH (Jan 01 1970). This uses the local system time.
+
 `time.sleep(secs: float)`
 
 The <b>time.sleep</b> method sleeps the task for the given number of seconds.

--- a/implants/lib/eldritch/src/lib.rs
+++ b/implants/lib/eldritch/src/lib.rs
@@ -227,7 +227,7 @@ dir(sys) == ["dll_inject", "dll_reflect", "exec", "get_env", "get_ip", "get_os",
 dir(pivot) == ["arp_scan", "bind_proxy", "ncat", "port_forward", "port_scan", "smb_exec", "ssh_copy", "ssh_exec", "ssh_password_spray"]
 dir(assets) == ["copy","list","read","read_binary"]
 dir(crypto) == ["aes_decrypt_file", "aes_encrypt_file", "decode_b64", "encode_b64", "from_json", "hash_file", "to_json"]
-dir(time) == ["sleep"]
+dir(time) == ["now", "sleep"]
 "#,
         );
     }

--- a/implants/lib/eldritch/src/time.rs
+++ b/implants/lib/eldritch/src/time.rs
@@ -1,4 +1,5 @@
 mod sleep_impl;
+mod now_impl;
 
 use allocative::Allocative;
 use derive_more::Display;
@@ -48,6 +49,10 @@ impl<'v> UnpackValue<'v> for TimeLibrary {
 #[starlark_module]
 #[rustfmt::skip]
 fn methods(builder: &mut MethodsBuilder) {
+    fn now<'v>(this: TimeLibrary) -> anyhow::Result<u64> {
+        if false { println!("Ignore unused this var. _this isn't allowed by starlark. {:?}", this); }
+        now_impl::now()
+    }
     fn sleep<'v>(this: TimeLibrary, secs: f64) -> anyhow::Result<NoneType> {
         if false { println!("Ignore unused this var. _this isn't allowed by starlark. {:?}", this); }
         sleep_impl::sleep(secs);

--- a/implants/lib/eldritch/src/time/now_impl.rs
+++ b/implants/lib/eldritch/src/time/now_impl.rs
@@ -1,0 +1,19 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+use anyhow::Result;
+
+pub fn now() -> Result<u64> {
+    Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::prelude::*;
+
+    #[test]
+    fn test_now() {
+        let now_out = now().unwrap() as i64;
+        let now_test = Local::now().timestamp();
+        assert!((now_out - now_test).abs() <= 250);
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
/kind feature
/kind eldritch-function

#### What this PR does / why we need it:
Adds `time.now()` to return local system time

#### Which issue(s) this PR fixes:
Fixes #76 
